### PR TITLE
Add Phase 2 dictionary lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
           pip install --no-build-isolation pyewts==0.2.0
           pip install -r requirements.txt
 
+      - name: Apply database schema
+        env:
+          PGPASSWORD: test_pass
+        run: |
+          psql -h localhost -U test_user -d test_db -f database/schema.sql
+
       - name: Run tests
         working-directory: ./backend
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ and this project uses
 
 ## [Unreleased]
 
+### Added
+
+- Dictionary-based word lookup (Phase 2) — structurally valid syllables are now
+  checked against a corpus of attested Tibetan words and flagged as `unknown_word`
+  if absent, surfaced as yellow warnings distinct from red structural errors
+- `spelling_reference` database table with normalized lookup, source tracking,
+  dialect and Sanskrit flags, and four indexes for fast access
+- `DictionaryService` — loads corpus at startup, extracts every valid syllable
+  from multi-syllable entries, O(1) frozenset lookup; degrades silently when no
+  database is configured
+- Corpus build scripts: `build_corpus.py` with scaffolded extractors for THDL,
+  Rangjung Yeshe, and Monlam; `seed_corpus.py` with ~55 hand-verified words for
+  pipeline testing
+- `corpus_hit` field on Phase 1 structural errors — flags when a flagged syllable
+  is nonetheless attested in the corpus, useful for monitoring potential false
+  positives over time
+- Structured JSON logging on every spell check (`spellcheck_result` tag) with
+  aggregate counts for analysis via `grep | jq`
+- `GET /api/v1/corpus/stats` endpoint
+- PDF spellcheck pipeline — upload a Tibetan PDF, get back an annotated DOCX with
+  each structurally invalid syllable marked; supports both digital PDFs and
+  scanned documents via OCR fallback
+- Async job support for PDF processing — upload returns a job ID; frontend polls
+  until complete
+- BDRC ONNX OCR engine for scanned PDFs, replacing Tesseract; model files
+  excluded from version control
+- Broken-CMap detection for digital PDFs — automatically falls back to OCR when
+  the PDF's character map is corrupt or missing (ADR-015)
+- OCR/copy-paste parity tests — fixture-based regression tests verifying that the
+  OCR and digital extraction paths produce equivalent spellcheck results
+- PDF spell check UI — upload form, job progress polling, email capture, results
+  display
+- Shared `PageTitle` and `SectionHeading` typography components adopted across
+  static pages
+
+### Changed
+
+- Particle validation tightened: ས, ར, ཞིག, and ཅིག marked as lenient to reduce
+  false positives; ཏུ handling improved; locative suggestions refined
+- PDF annotation and DOCX export refactored to syllable granularity
+- Digital PDF extraction migrated from pdfplumber to fitz for better CMap support
+
+### Removed
+
+- JSON download endpoint removed from PDF spellcheck pipeline
+
 ---
 
 ## [0.2.0] - 2026-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project uses
 - Structured JSON logging on every spell check (`spellcheck_result` tag) with
   aggregate counts for analysis via `grep | jq`
 - `GET /api/v1/corpus/stats` endpoint
+
+---
+
+## [0.3.0] - 2026-04-01
+
+### Added
+
 - PDF spellcheck pipeline — upload a Tibetan PDF, get back an annotated DOCX with
   each structurally invalid syllable marked; supports both digital PDFs and
   scanned documents via OCR fallback

--- a/backend/app/api/corpus.py
+++ b/backend/app/api/corpus.py
@@ -1,0 +1,25 @@
+"""
+Corpus API endpoints — word corpus statistics.
+"""
+from fastapi import APIRouter
+
+from app.schemas.spellcheck import CorpusStatsResponse
+from app.spellcheck.dictionary import DictionaryService
+
+router = APIRouter()
+
+# Shared instance — loaded once at module import time.
+_dictionary = DictionaryService()
+
+
+@router.get("/corpus/stats", response_model=CorpusStatsResponse)
+async def corpus_stats():
+    """
+    Return statistics about the loaded word corpus.
+
+    - **available**: whether dictionary lookup is active (requires DATABASE_URL
+      and a populated spelling_reference table)
+    - **word_count**: number of entries in spelling_reference
+    - **syllable_count**: unique syllables extracted from all entries
+    """
+    return CorpusStatsResponse(**_dictionary.stats())

--- a/backend/app/api/spellcheck.py
+++ b/backend/app/api/spellcheck.py
@@ -1,6 +1,7 @@
 """
 Spell check API endpoints — text and PDF upload.
 """
+import json
 import logging
 from pathlib import Path
 
@@ -58,9 +59,16 @@ async def check_text(request: SpellCheckRequest):
                 severity=error.get("severity", "error"),
                 message=error.get("message"),
                 component=error.get("component"),
+                corpus_hit=error.get("corpus_hit"),
             )
             for error in raw_errors
         ]
+
+        _log_spellcheck_result(
+            source="text",
+            text_length=len(request.text),
+            errors=raw_errors,
+        )
 
         return SpellCheckResponse(
             text=request.text,
@@ -134,6 +142,12 @@ async def _process_sync(pdf_bytes: bytes, filename: str, page_count: int):
         docx_path.write_bytes(docx_bytes)
 
         job_store.mark_completed(job.id, pdf_path, docx_path, all_errors)
+
+        _log_spellcheck_result(
+            source="pdf",
+            text_length=sum(len(p.text) for p in pages),
+            errors=all_errors,
+        )
 
         return PDFUploadSyncResponse(
             job_id=job.id,
@@ -235,6 +249,43 @@ def _background_process(job_id: str, upload_path: Path, filename: str, email: st
             pass
 
 
+def _log_spellcheck_result(source: str, text_length: int, errors: list[dict]) -> None:
+    """
+    Emit a structured log line for every spell check result.
+
+    Each line starts with 'spellcheck_result' so it can be isolated with:
+        grep spellcheck_result <logfile>
+        grep spellcheck_result <logfile> | jq '.corpus_hits'
+
+    Fields:
+        source        — "text" or "pdf"
+        text_length   — character count of input
+        error_count   — total errors returned
+        phase1_errors — structural errors (severity != warning and != info)
+        unknown_words — syllables flagged by Phase 2 dictionary lookup
+        corpus_hits   — Phase 1 errors where the syllable WAS in the corpus
+                        (potential false positives; key metric for tuning)
+        dict_active   — whether the dictionary was loaded for this check
+    """
+    phase1 = [e for e in errors if e.get("severity") not in ("warning", "info")]
+    unknown = [e for e in errors if e.get("error_type") == "unknown_word"]
+    corpus_hits = [e for e in phase1 if e.get("corpus_hit") is True]
+    dict_active = any(e.get("corpus_hit") is not None for e in errors)
+
+    logger.info(
+        "spellcheck_result %s",
+        json.dumps({
+            "source": source,
+            "text_length": text_length,
+            "error_count": len(errors),
+            "phase1_errors": len(phase1),
+            "unknown_words": len(unknown),
+            "corpus_hits": len(corpus_hits),
+            "dict_active": dict_active,
+        }),
+    )
+
+
 def _run_spellcheck(pages) -> tuple[dict[int, list[str]], list[dict]]:
     """
     Run the spell checker over all extracted page text.
@@ -266,6 +317,7 @@ def _run_spellcheck(pages) -> tuple[dict[int, list[str]], list[dict]]:
                     "severity": e.get("severity", "error"),
                     "message": e.get("message"),
                     "component": e.get("component"),
+                    "corpus_hit": e.get("corpus_hit"),
                 }
             )
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     # Requires models to be downloaded first: python scripts/download_models.py
     ocr_model_name: str = "Woodblock"
 
+    # Database URL for the spelling reference / word corpus.
+    # When unset, dictionary lookup is silently skipped and only structural
+    # (Phase 1) validation runs.  Set to a postgres:// DSN for full Phase 2 support.
+    database_url: str | None = None
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,71 @@
+"""
+Database connection layer.
+
+Provides a SQLAlchemy engine and session factory wired to DATABASE_URL from
+settings.  Both are None when DATABASE_URL is not configured so callers can
+skip DB work gracefully instead of crashing.
+
+Usage:
+    from app.database import get_session
+
+    with get_session() as session:
+        rows = session.execute(text("SELECT 1")).fetchall()
+
+Or check availability first:
+    from app.database import db_available
+    if db_available():
+        ...
+"""
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+
+_engine = None
+_SessionFactory = None
+
+if settings.database_url:
+    _engine = create_engine(
+        settings.database_url,
+        pool_pre_ping=True,   # detect stale connections
+        pool_size=5,
+        max_overflow=10,
+    )
+    _SessionFactory = sessionmaker(bind=_engine, expire_on_commit=False)
+
+
+def db_available() -> bool:
+    """Return True if a database URL was configured and a connection can be made."""
+    if _engine is None:
+        return False
+    try:
+        with _engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+@contextmanager
+def get_session() -> Generator[Session, None, None]:
+    """
+    Yield a SQLAlchemy Session, rolling back on error and always closing.
+
+    Raises RuntimeError if no DATABASE_URL is configured.
+    """
+    if _SessionFactory is None:
+        raise RuntimeError(
+            "Database is not configured. Set DATABASE_URL in your environment or .env file."
+        )
+    session: Session = _SessionFactory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api import health, spellcheck
+from app.api import corpus, health, spellcheck
 from app.config import settings
 
 app = FastAPI(
@@ -21,3 +21,4 @@ app.add_middleware(
 # Include routers
 app.include_router(health.router, prefix="/api/v1", tags=["health"])
 app.include_router(spellcheck.router, prefix="/api/v1", tags=["spellcheck"])
+app.include_router(corpus.router, prefix="/api/v1", tags=["corpus"])

--- a/backend/app/schemas/spellcheck.py
+++ b/backend/app/schemas/spellcheck.py
@@ -31,12 +31,12 @@ class ErrorResponse(BaseModel):
     error_type: str = Field(
         ...,
         description="Type of spelling error detected",
-        examples=["invalid_prefix_combination", "invalid_suffix", "encoding_error"]
+        examples=["invalid_prefix_combination", "invalid_suffix", "encoding_error", "unknown_word"]
     )
     severity: str = Field(
         ...,
         description="Severity level of the error",
-        examples=["critical", "error", "info"]
+        examples=["critical", "error", "warning", "info"]
     )
     message: str | None = Field(
         None,
@@ -46,6 +46,14 @@ class ErrorResponse(BaseModel):
         None,
         description="Which syllable component has the error",
         examples=["prefix", "suffix", "superscript", "subscript"]
+    )
+    corpus_hit: bool | None = Field(
+        None,
+        description=(
+            "Whether this syllable was found in the word corpus. "
+            "True on a structural error means the Phase 1 rule may be a false positive. "
+            "None means the corpus was not loaded."
+        )
     )
 
 
@@ -86,6 +94,7 @@ class PDFErrorResponse(BaseModel):
     severity: str
     message: Optional[str] = None
     component: Optional[str] = None
+    corpus_hit: Optional[bool] = None
 
 
 class PDFUploadSyncResponse(BaseModel):
@@ -117,3 +126,21 @@ class JobStatusResponse(BaseModel):
     error_message: Optional[str] = None
     pdf_url: Optional[str] = None
     docx_url: Optional[str] = None
+
+
+class CorpusStatsResponse(BaseModel):
+    """Statistics about the loaded word corpus."""
+    available: bool = Field(
+        ...,
+        description="True if the word corpus is loaded and dictionary lookup is active"
+    )
+    word_count: int = Field(
+        ...,
+        description="Number of entries in the spelling_reference table",
+        ge=0
+    )
+    syllable_count: int = Field(
+        ...,
+        description="Number of unique syllables extracted from all corpus entries",
+        ge=0
+    )

--- a/backend/app/spellcheck/dictionary.py
+++ b/backend/app/spellcheck/dictionary.py
@@ -1,0 +1,131 @@
+"""
+DictionaryService — Phase 2 word corpus lookup.
+
+Loads all entries from the spelling_reference table at construction time,
+extracts every individual syllable from every word (splitting on tsheg), and
+builds an in-memory frozenset for O(1) per-syllable validity checks.
+
+This sidesteps the Tibetan word-segmentation problem: rather than trying to
+identify word boundaries in the input text (which requires a probabilistic
+model), we ask a simpler question: "does this syllable appear in any legitimate
+Tibetan word in our corpus?"  A syllable like ཡིབ that is structurally valid
+but never occurs in real Tibetan will not be in the inventory and gets flagged.
+
+Limitation: cannot detect valid-syllable sequences that form nonsense compounds
+(e.g. བོད་ཡིབ་).  That requires word segmentation and is deferred to Phase 3.
+
+Usage:
+    from app.spellcheck.dictionary import DictionaryService
+
+    svc = DictionaryService()          # loads from DB, or no-op if unavailable
+    if svc.available:
+        valid = svc.is_valid_syllable("བོད")   # True
+        valid = svc.is_valid_syllable("ཡིབ")   # False
+    else:
+        # No database — Phase 1 only, no dictionary check
+        pass
+"""
+import logging
+import unicodedata
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+TSHEG = "\u0F0B"  # ་
+
+
+def _normalize(text: str) -> str:
+    """NFC-normalize Tibetan text (consistent with the spellcheck normalizer)."""
+    return unicodedata.normalize("NFC", text)
+
+
+def _syllables_from_word(word: str) -> list[str]:
+    """
+    Split a dictionary entry (possibly multi-syllable) into its component
+    syllables.  Strips leading/trailing whitespace from each piece.
+    """
+    return [s.strip() for s in word.split(TSHEG) if s.strip()]
+
+
+class DictionaryService:
+    """
+    In-memory syllable inventory built from the spelling_reference table.
+
+    Attributes:
+        available: True if a database was reachable and at least one word
+                   was loaded.  When False, is_valid_syllable returns None
+                   and callers should skip the dictionary check entirely.
+        word_count: Number of corpus entries loaded.
+        syllable_count: Number of unique syllables in the inventory.
+    """
+
+    def __init__(self) -> None:
+        self._syllables: frozenset[str] = frozenset()
+        self.word_count: int = 0
+        self.syllable_count: int = 0
+        self.available: bool = False
+        self._load()
+
+    def _load(self) -> None:
+        """Query spelling_reference and build the syllable inventory."""
+        try:
+            from app.database import db_available, get_session
+        except ImportError:
+            logger.debug("database module not available; dictionary disabled")
+            return
+
+        if not db_available():
+            logger.info(
+                "No database connection; dictionary lookup disabled (Phase 1 only)"
+            )
+            return
+
+        try:
+            from sqlalchemy import text
+
+            with get_session() as session:
+                rows = session.execute(
+                    text("SELECT word_normalized FROM spelling_reference")
+                ).fetchall()
+
+            syllable_set: set[str] = set()
+            for (word,) in rows:
+                for syl in _syllables_from_word(_normalize(word)):
+                    syllable_set.add(syl)
+
+            self._syllables = frozenset(syllable_set)
+            self.word_count = len(rows)
+            self.syllable_count = len(self._syllables)
+            self.available = self.word_count > 0
+
+            logger.info(
+                "DictionaryService loaded: %d words → %d unique syllables",
+                self.word_count,
+                self.syllable_count,
+            )
+
+        except Exception:
+            logger.exception(
+                "Failed to load spelling_reference; dictionary lookup disabled"
+            )
+
+    def is_valid_syllable(self, syllable: str) -> Optional[bool]:
+        """
+        Check whether a syllable appears in the corpus inventory.
+
+        Returns:
+            True  — syllable is in the corpus (valid)
+            False — syllable is NOT in the corpus (flag as unknown_word)
+            None  — corpus not loaded; caller should skip the check
+        """
+        if not self.available:
+            return None
+        return _normalize(syllable) in self._syllables
+
+    def stats(self) -> dict:
+        """Summary stats for the /corpus/stats API endpoint."""
+        return {
+            "available": self.available,
+            "word_count": self.word_count,
+            "syllable_count": self.syllable_count,
+        }

--- a/backend/app/spellcheck/engine.py
+++ b/backend/app/spellcheck/engine.py
@@ -105,9 +105,14 @@ class TibetanSpellChecker:
         # 4. Component validation (stacking rules)
         errors = validate_syllable(parsed_model)
         if errors:
-            # Return the first error as a dict for backwards compatibility
             error_dict = errors[0].to_dict()
             error_dict['word'] = syllable
+            # Even though Phase 1 flagged this syllable, check whether it
+            # exists in the corpus.  corpus_hit=True on a structural error
+            # is a signal that the Phase 1 rule may be producing a false
+            # positive on a real word — useful data for future tuning.
+            in_corpus = self._dictionary.is_valid_syllable(syllable)
+            error_dict['corpus_hit'] = None if in_corpus is None else bool(in_corpus)
             return error_dict
 
         # 5. Dictionary lookup (Phase 2) — only runs when corpus is loaded.
@@ -125,6 +130,7 @@ class TibetanSpellChecker:
                     "have yet."
                 ),
                 'component': None,
+                'corpus_hit': False,
             }
 
         # No errors found

--- a/backend/app/spellcheck/engine.py
+++ b/backend/app/spellcheck/engine.py
@@ -22,6 +22,7 @@ from .validation import (
     check_particle_context,
 )
 from .rules.exceptions import is_excepted
+from .dictionary import DictionaryService
 
 
 class TibetanSpellChecker:
@@ -30,11 +31,24 @@ class TibetanSpellChecker:
 
     Integrates Unicode normalization, syllable parsing, and validation
     to check Tibetan text for spelling errors.
+
+    Phase 1: structural/grammatical validation (always active)
+    Phase 2: dictionary lookup against the word corpus (active when a database
+             is configured and the spelling_reference table has been populated)
     """
 
-    def __init__(self):
-        """Initialize the spell checker."""
-        pass
+    def __init__(self, dictionary: DictionaryService | None = None):
+        """
+        Initialize the spell checker.
+
+        Args:
+            dictionary: A pre-built DictionaryService instance.  When None
+                        (the default) a new instance is created, which
+                        attempts to connect to the database.  Pass an explicit
+                        instance to share one service across multiple checker
+                        instances (e.g. in tests).
+        """
+        self._dictionary = dictionary if dictionary is not None else DictionaryService()
 
     def check_syllable(self, syllable: str) -> Optional[Dict]:
         """
@@ -95,6 +109,23 @@ class TibetanSpellChecker:
             error_dict = errors[0].to_dict()
             error_dict['word'] = syllable
             return error_dict
+
+        # 5. Dictionary lookup (Phase 2) — only runs when corpus is loaded.
+        # is_valid_syllable returns None when the corpus is unavailable, in
+        # which case we skip rather than flag everything as unknown.
+        in_corpus = self._dictionary.is_valid_syllable(syllable)
+        if in_corpus is False:
+            return {
+                'word': syllable,
+                'error_type': 'unknown_word',
+                'severity': 'warning',
+                'message': (
+                    f"'{syllable}' is structurally valid but not found in the "
+                    "word corpus. It may be a spelling error or a word we don't "
+                    "have yet."
+                ),
+                'component': None,
+            }
 
         # No errors found
         return None

--- a/backend/scripts/build_corpus.py
+++ b/backend/scripts/build_corpus.py
@@ -1,0 +1,313 @@
+"""
+Tibetan word corpus builder.
+
+Extracts Tibetan words from multiple dictionary sources, cross-references them
+(keeping only words that appear in 2+ sources for quality assurance), and loads
+the result into the spelling_reference table.
+
+See docs/planning/WORD_CORPUS_PLAN.md for the sourcing strategy.
+
+Usage:
+    # From backend/ directory with venv active:
+    python scripts/build_corpus.py --help
+    python scripts/build_corpus.py --dry-run           # preview counts, no DB write
+    python scripts/build_corpus.py --sources thdl ry   # specific sources only
+    python scripts/build_corpus.py                     # all available sources → DB
+
+Sources status:
+    thdl            — THDL (Tibetan & Himalayan Digital Library)
+                      TODO: Download dictionary from https://www.thlib.org
+                      Expected format: XML or plain text
+                      License: open educational use (verify before redistribution)
+
+    rangjung_yeshe  — Rangjung Yeshe Wiki (Buddhist terminology)
+                      TODO: Export via MediaWiki API at https://rywiki.tsadra.org
+                      Expected format: MediaWiki XML export or API JSON
+                      License: check Creative Commons specifics
+
+    monlam          — Monlam Grand Tibetan Dictionary (~100k entries)
+                      TODO: Contact Monlam IT for research/educational access
+                      URL: https://www.monlam.ai
+                      Status: permission required before use
+"""
+import argparse
+import json
+import logging
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Iterator
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+TSHEG = "\u0F0B"  # ་
+TIBETAN_RANGE = (0x0F00, 0x0FFF)
+
+# Minimum number of sources a word must appear in to be included.
+CROSS_REFERENCE_THRESHOLD = 2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def normalize(text: str) -> str:
+    return unicodedata.normalize("NFC", text.strip())
+
+
+def is_tibetan(text: str) -> bool:
+    """Return True if text contains at least one Tibetan Unicode character."""
+    return any(TIBETAN_RANGE[0] <= ord(c) <= TIBETAN_RANGE[1] for c in text)
+
+
+# ---------------------------------------------------------------------------
+# Source extractors
+# ---------------------------------------------------------------------------
+
+def extract_thdl(data_path: Path) -> Iterator[str]:
+    """
+    Extract Tibetan headwords from a THDL dictionary file.
+
+    TODO: Implement once the THDL dataset has been downloaded.
+          Expected: XML or tab-separated text with Tibetan headwords.
+
+    Args:
+        data_path: Path to the downloaded THDL dictionary file.
+
+    Yields:
+        Tibetan word strings (un-normalized; normalization happens downstream).
+    """
+    if not data_path.exists():
+        logger.warning("THDL data file not found: %s — skipping source", data_path)
+        return
+
+    raise NotImplementedError(
+        "THDL extractor not yet implemented. "
+        "Download the dictionary from https://www.thlib.org first, "
+        "then implement the parser for its format here."
+    )
+
+
+def extract_rangjung_yeshe(data_path: Path) -> Iterator[str]:
+    """
+    Extract Tibetan headwords from a Rangjung Yeshe Wiki export.
+
+    TODO: Implement once the wiki export has been obtained.
+          Use the MediaWiki API: https://rywiki.tsadra.org/api.php
+          or a full XML dump export.
+
+    Args:
+        data_path: Path to the downloaded wiki export file.
+
+    Yields:
+        Tibetan word strings.
+    """
+    if not data_path.exists():
+        logger.warning("Rangjung Yeshe data file not found: %s — skipping source", data_path)
+        return
+
+    raise NotImplementedError(
+        "Rangjung Yeshe extractor not yet implemented. "
+        "Export the wiki via MediaWiki API first, "
+        "then implement the parser here."
+    )
+
+
+def extract_monlam(data_path: Path) -> Iterator[str]:
+    """
+    Extract Tibetan headwords from the Monlam Grand Tibetan Dictionary.
+
+    TODO: Contact Monlam IT (https://www.monlam.ai) for research access.
+          Do not use without explicit permission.
+
+    Args:
+        data_path: Path to the Monlam dataset file.
+
+    Yields:
+        Tibetan word strings.
+    """
+    if not data_path.exists():
+        logger.warning("Monlam data file not found: %s — skipping source", data_path)
+        return
+
+    raise NotImplementedError(
+        "Monlam extractor not yet implemented. "
+        "Obtain permission and dataset from Monlam IT first."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-referencing
+# ---------------------------------------------------------------------------
+
+def cross_reference(
+    sources: dict[str, list[str]],
+    threshold: int = CROSS_REFERENCE_THRESHOLD,
+) -> list[dict]:
+    """
+    Combine word lists from multiple sources and filter by cross-reference count.
+
+    Args:
+        sources: Mapping of source_name → list of (un-normalized) Tibetan words.
+        threshold: Minimum number of sources a word must appear in to be kept.
+
+    Returns:
+        List of dicts ready for insertion into spelling_reference.
+    """
+    word_data: dict[str, dict] = {}
+
+    for source_name, words in sources.items():
+        seen_in_source: set[str] = set()
+        for raw_word in words:
+            word = normalize(raw_word)
+            if not word or not is_tibetan(word):
+                continue
+            if word in seen_in_source:
+                continue
+            seen_in_source.add(word)
+
+            if word not in word_data:
+                word_data[word] = {"sources": [], "source_count": 0}
+            word_data[word]["sources"].append(source_name)
+            word_data[word]["source_count"] += 1
+
+    total = len(word_data)
+    validated = [
+        {
+            "word": word,
+            "word_normalized": word,
+            "source_count": data["source_count"],
+            "sources": data["sources"],
+            "first_seen_in": data["sources"][0],
+        }
+        for word, data in word_data.items()
+        if data["source_count"] >= threshold
+    ]
+
+    logger.info(
+        "Cross-reference: %d total unique words → %d validated (threshold: %d+ sources)",
+        total,
+        len(validated),
+        threshold,
+    )
+    return validated
+
+
+# ---------------------------------------------------------------------------
+# Database loader
+# ---------------------------------------------------------------------------
+
+def load_to_database(words: list[dict], replace: bool = False) -> int:
+    """
+    Insert validated words into spelling_reference.
+
+    Args:
+        words: List of word dicts from cross_reference().
+        replace: If True, truncate the table before inserting.
+
+    Returns:
+        Number of rows inserted.
+    """
+    # Import here so the script can be imported without a live DB for --dry-run
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+    from sqlalchemy import text
+    from app.database import get_session, db_available
+
+    if not db_available():
+        logger.error("No database connection. Set DATABASE_URL and try again.")
+        return 0
+
+    inserted = 0
+    with get_session() as session:
+        if replace:
+            session.execute(text("TRUNCATE spelling_reference"))
+            logger.info("Truncated spelling_reference")
+
+        for w in words:
+            session.execute(
+                text("""
+                    INSERT INTO spelling_reference
+                        (word, word_normalized, source_count, sources, first_seen_in)
+                    VALUES
+                        (:word, :word_normalized, :source_count, :sources::jsonb,
+                         :first_seen_in)
+                    ON CONFLICT (word) DO UPDATE SET
+                        source_count = EXCLUDED.source_count,
+                        sources      = EXCLUDED.sources
+                """),
+                {**w, "sources": json.dumps(w["sources"])},
+            )
+            inserted += 1
+
+    logger.info("Inserted/updated %d words in spelling_reference", inserted)
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+SOURCE_MAP = {
+    "thdl": ("thdl", extract_thdl, Path("data/thdl_dictionary.txt")),
+    "ry": ("rangjung_yeshe", extract_rangjung_yeshe, Path("data/rangjung_yeshe_export.xml")),
+    "monlam": ("monlam", extract_monlam, Path("data/monlam_export.json")),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build Tibetan word corpus")
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        choices=list(SOURCE_MAP.keys()),
+        default=list(SOURCE_MAP.keys()),
+        help="Which sources to include (default: all)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=CROSS_REFERENCE_THRESHOLD,
+        help=f"Minimum sources required per word (default: {CROSS_REFERENCE_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print counts but do not write to the database",
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Truncate spelling_reference before inserting (full rebuild)",
+    )
+    args = parser.parse_args()
+
+    collected: dict[str, list[str]] = {}
+    for key in args.sources:
+        source_name, extractor_fn, data_path = SOURCE_MAP[key]
+        try:
+            words = list(extractor_fn(data_path))
+            collected[source_name] = words
+            logger.info("Source '%s': %d words", source_name, len(words))
+        except NotImplementedError as e:
+            logger.warning("Skipping source '%s': %s", key, e)
+        except Exception:
+            logger.exception("Error reading source '%s'", key)
+
+    if not collected:
+        logger.error("No sources produced any words. Exiting.")
+        sys.exit(1)
+
+    validated = cross_reference(collected, threshold=args.threshold)
+
+    if args.dry_run:
+        logger.info("Dry run — %d words would be written to spelling_reference", len(validated))
+        return
+
+    load_to_database(validated, replace=args.replace)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/seed_corpus.py
+++ b/backend/scripts/seed_corpus.py
@@ -1,0 +1,141 @@
+"""
+Seed the spelling_reference table with a small hand-verified word list.
+
+This is NOT a replacement for the full corpus build (see build_corpus.py).
+Its purpose is to:
+  1. Enable end-to-end testing of the Phase 2 pipeline before the full
+     corpus has been sourced and licensed.
+  2. Provide a known-good baseline for regression tests.
+  3. Serve as a template showing the expected data shape.
+
+Usage:
+    # From backend/ directory with venv active and DATABASE_URL set:
+    python scripts/seed_corpus.py           # insert, skip existing
+    python scripts/seed_corpus.py --replace # truncate first (full reset)
+
+Words here are drawn from common Tibetan Buddhist texts and verified against
+multiple reference dictionaries.  Each entry notes which sources confirm it.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Seed data — hand-verified words for pipeline testing.
+# Source is "seed_corpus" (honest: not yet cross-referenced against external
+# dictionaries).  Replace with build_corpus.py output once sources are sourced.
+# ---------------------------------------------------------------------------
+
+SEED_WORDS = [
+    # --- Common Tibetan words ---
+    "བོད",
+    "ཡིག",
+    "བོད་ཡིག",
+    "སྐད",
+    "ལུང",
+    "གཞུང",
+    "དེབ",
+    "ཆོས",
+    "ལམ",
+    "མི",
+    "གང",
+    "འདི",
+    "ཐམས་ཅད",
+    "ཞིག",
+    # --- Buddhist / liturgical terms ---
+    "སངས་རྒྱས",
+    "དགེ་འདུན",
+    "བླ་མ",
+    "རིན་པོ་ཆེ",
+    "དཀོན་མཆོག",
+    "སྒོམ",
+    "སྒྲུབ",
+    "སེམས",
+    "ཤེས་རབ",
+    "སྙིང་རྗེ",
+    "བྱང་ཆུབ",
+    "སྟོང་པ",
+    "སྟོང་པ་ཉིད",
+    "སྤྱན་རས་གཟིགས",
+    "རྡོ་རྗེ",
+    "པདྨ",
+    "མཁའ་འགྲོ",
+    "དམར་ཆེན",
+    "ཚེ",
+    "ལྷ",
+    "གཏེར",
+    "གུ་རུ",
+    # --- Grammatical particles ---
+    "ཀྱི",
+    "གྱི",
+    "ཡི",
+    "ཀྱིས",
+    "གྱིས",
+    "ལ",
+    "དང",
+    "ནས",
+    "ནི",
+    "ཏུ",
+    "དུ",
+    "རུ",
+    "སུ",
+    "པ",
+    "བ",
+    "མཐོང",
+]
+
+import unicodedata
+
+def normalize(text: str) -> str:
+    return unicodedata.normalize("NFC", text.strip())
+
+
+def seed(replace: bool = False) -> int:
+    from sqlalchemy import text
+    from app.database import get_session, db_available
+
+    if not db_available():
+        logger.error("No database connection. Set DATABASE_URL and try again.")
+        return 0
+
+    inserted = 0
+    with get_session() as session:
+        if replace:
+            session.execute(text("TRUNCATE spelling_reference"))
+            logger.info("Truncated spelling_reference")
+
+        for raw_word in SEED_WORDS:
+            word = normalize(raw_word)
+            session.execute(
+                text("""
+                    INSERT INTO spelling_reference
+                        (word, word_normalized, source_count, sources, first_seen_in)
+                    VALUES
+                        (:word, :word_normalized, 1, '["seed_corpus"]'::jsonb, 'seed_corpus')
+                    ON CONFLICT (word) DO NOTHING
+                """),
+                {"word": word, "word_normalized": word},
+            )
+            inserted += 1
+
+    logger.info("Seeded %d words into spelling_reference", inserted)
+    return inserted
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Seed spelling_reference with a small verified word list")
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Truncate spelling_reference before seeding",
+    )
+    args = parser.parse_args()
+    seed(replace=args.replace)

--- a/backend/tests/test_dictionary.py
+++ b/backend/tests/test_dictionary.py
@@ -1,0 +1,144 @@
+"""
+Tests for DictionaryService.
+
+All tests use an injected in-memory word list so no database is required.
+The DB-loading path (_load) is covered by verifying graceful degradation
+when DATABASE_URL is absent (already exercised in the CI environment).
+"""
+import unicodedata
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.spellcheck.dictionary import DictionaryService, _normalize, _syllables_from_word
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a DictionaryService pre-loaded with a known word list
+# ---------------------------------------------------------------------------
+
+def make_service(words: list[str]) -> DictionaryService:
+    """Return a DictionaryService with its syllable inventory pre-populated."""
+    svc = DictionaryService.__new__(DictionaryService)
+    syllables: set[str] = set()
+    for word in words:
+        for syl in _syllables_from_word(_normalize(word)):
+            syllables.add(syl)
+    svc._syllables = frozenset(syllables)
+    svc.word_count = len(words)
+    svc.syllable_count = len(syllables)
+    svc.available = len(words) > 0
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# _normalize
+# ---------------------------------------------------------------------------
+
+class TestNormalize:
+    def test_nfc_normalization(self):
+        # Both forms of the same Tibetan text should normalize to the same string
+        raw = "བོད"
+        assert _normalize(raw) == unicodedata.normalize("NFC", raw)
+
+    def test_strips_whitespace(self):
+        # _normalize applies NFC; stripping is done by _syllables_from_word, not here
+        result = _normalize("  བོད  ")
+        assert "བོད" in result
+
+    def test_empty_string(self):
+        assert _normalize("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _syllables_from_word
+# ---------------------------------------------------------------------------
+
+class TestSyllablesFromWord:
+    def test_single_syllable(self):
+        assert _syllables_from_word("བོད") == ["བོད"]
+
+    def test_two_syllables(self):
+        result = _syllables_from_word("བོད་ཡིག")
+        assert result == ["བོད", "ཡིག"]
+
+    def test_three_syllables(self):
+        result = _syllables_from_word("སྤྱན་རས་གཟིགས")
+        assert result == ["སྤྱན", "རས", "གཟིགས"]
+
+    def test_trailing_tsheg(self):
+        # Trailing tsheg should not produce an empty syllable
+        result = _syllables_from_word("བོད་ཡིག་")
+        assert result == ["བོད", "ཡིག"]
+        assert "" not in result
+
+    def test_empty_string(self):
+        assert _syllables_from_word("") == []
+
+
+# ---------------------------------------------------------------------------
+# DictionaryService — graceful degradation (no database)
+# ---------------------------------------------------------------------------
+
+class TestDictionaryServiceNoDB:
+    def test_available_is_false_without_db(self):
+        # db_available is imported inside _load(), so patch it at the source module
+        with patch("app.database.db_available", return_value=False):
+            svc = DictionaryService()
+        assert svc.available is False
+
+    def test_is_valid_syllable_returns_none_when_unavailable(self):
+        svc = make_service([])
+        svc.available = False
+        assert svc.is_valid_syllable("བོད") is None
+
+    def test_stats_when_unavailable(self):
+        svc = make_service([])
+        svc.available = False
+        stats = svc.stats()
+        assert stats["available"] is False
+        assert stats["word_count"] == 0
+        assert stats["syllable_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# DictionaryService — lookup with a known corpus
+# ---------------------------------------------------------------------------
+
+class TestDictionaryServiceLookup:
+    @pytest.fixture
+    def svc(self):
+        return make_service([
+            "བོད",           # single syllable
+            "བོད་ཡིག",       # two syllables
+            "སྤྱན་རས་གཟིགས", # three syllables
+            "སངས་རྒྱས",      # Buddhist term
+        ])
+
+    def test_known_single_syllable_is_valid(self, svc):
+        assert svc.is_valid_syllable("བོད") is True
+
+    def test_syllable_from_multi_syllable_word_is_valid(self, svc):
+        # ཡིག appears only as part of བོད་ཡིག — should still be valid
+        assert svc.is_valid_syllable("ཡིག") is True
+
+    def test_syllable_from_three_syllable_word_is_valid(self, svc):
+        assert svc.is_valid_syllable("རས") is True
+        assert svc.is_valid_syllable("གཟིགས") is True
+
+    def test_unknown_syllable_returns_false(self, svc):
+        # ཡིབ is structurally valid Tibetan but not in this corpus
+        assert svc.is_valid_syllable("ཡིབ") is False
+
+    def test_normalization_applied_on_lookup(self, svc):
+        # Lookup should normalize before checking — same syllable, different form
+        raw = "བོད"
+        nfc = unicodedata.normalize("NFC", raw)
+        assert svc.is_valid_syllable(raw) == svc.is_valid_syllable(nfc)
+
+    def test_stats_reflect_loaded_corpus(self, svc):
+        stats = svc.stats()
+        assert stats["available"] is True
+        assert stats["word_count"] == 4
+        # 4 words → བོད, ཡིག, བོད (dup), སྤྱན, རས, གཟིགས, སངས, རྒྱས = 7 unique
+        assert stats["syllable_count"] == 7

--- a/backend/tests/test_engine_dictionary.py
+++ b/backend/tests/test_engine_dictionary.py
@@ -1,0 +1,155 @@
+"""
+Integration tests for the spell check engine with Phase 2 dictionary lookup.
+
+Uses an injected DictionaryService pre-loaded with a small known-good corpus
+so no database is required.  Tests verify:
+  - unknown_word warning fires for valid-structure syllables absent from corpus
+  - corpus_hit is populated on Phase 1 structural errors
+  - Phase 2 is silently skipped when the dictionary is unavailable
+  - known-good syllables still pass cleanly end-to-end
+"""
+import pytest
+
+from app.spellcheck.dictionary import DictionaryService
+from app.spellcheck.engine import TibetanSpellChecker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_dictionary(*words: str) -> DictionaryService:
+    """Return a DictionaryService pre-loaded with the given words."""
+    from app.spellcheck.dictionary import _normalize, _syllables_from_word
+
+    svc = DictionaryService.__new__(DictionaryService)
+    syllables: set[str] = set()
+    for word in words:
+        for syl in _syllables_from_word(_normalize(word)):
+            syllables.add(syl)
+    svc._syllables = frozenset(syllables)
+    svc.word_count = len(words)
+    svc.syllable_count = len(syllables)
+    svc.available = True
+    return svc
+
+
+def unavailable_dictionary() -> DictionaryService:
+    """Return a DictionaryService with no corpus loaded (simulates no DB)."""
+    svc = DictionaryService.__new__(DictionaryService)
+    svc._syllables = frozenset()
+    svc.word_count = 0
+    svc.syllable_count = 0
+    svc.available = False
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: unknown_word warnings
+# ---------------------------------------------------------------------------
+
+class TestUnknownWordWarning:
+    def test_valid_syllable_in_corpus_passes(self):
+        """A structurally valid syllable that IS in the corpus produces no error."""
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད", "ཡིག"))
+        result = checker.check_syllable("བོད")
+        assert result is None
+
+    def test_valid_syllable_not_in_corpus_flagged(self):
+        """A structurally valid syllable NOT in the corpus gets unknown_word warning."""
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད"))
+        result = checker.check_syllable("ཡིག")
+        assert result is not None
+        assert result["error_type"] == "unknown_word"
+        assert result["severity"] == "warning"
+        assert result["corpus_hit"] is False
+
+    def test_unknown_word_message_is_helpful(self):
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད"))
+        result = checker.check_syllable("ཡིག")
+        assert result is not None
+        assert "structurally valid" in result["message"]
+
+    def test_check_text_returns_unknown_word_warnings(self):
+        """check_text surfaces unknown_word warnings in the error list."""
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད"))
+        errors = checker.check_text("བོད་ཡིབ་")
+        # བོད is in corpus (clean), ཡིབ is not
+        unknown = [e for e in errors if e.get("error_type") == "unknown_word"]
+        assert len(unknown) == 1
+        assert unknown[0]["word"] == "ཡིབ"
+
+    def test_warning_does_not_suppress_subsequent_syllables(self):
+        """unknown_word on one syllable doesn't affect checking of the next."""
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད"))
+        errors = checker.check_text("ཡིབ་བོད་")
+        unknown = [e for e in errors if e["error_type"] == "unknown_word"]
+        assert len(unknown) == 1  # only ཡིབ
+
+
+# ---------------------------------------------------------------------------
+# corpus_hit on Phase 1 structural errors
+# ---------------------------------------------------------------------------
+
+class TestCorpusHitOnStructuralErrors:
+    def test_structural_error_with_corpus_miss_has_false_corpus_hit(self):
+        """A structurally invalid syllable not in the corpus: corpus_hit=False."""
+        checker = TibetanSpellChecker(dictionary=make_dictionary("བོད"))
+        # གཀར is structurally invalid (ག cannot prefix ཀ)
+        result = checker.check_syllable("གཀར")
+        assert result is not None
+        assert result["severity"] == "error"
+        assert result["corpus_hit"] is False
+
+    def test_structural_error_with_corpus_hit_has_true_corpus_hit(self):
+        """A structurally invalid syllable that IS in the corpus: corpus_hit=True.
+        This is the signal that Phase 1 may be producing a false positive."""
+        # Deliberately add the structurally-flagged syllable to the corpus
+        checker = TibetanSpellChecker(dictionary=make_dictionary("གཀར"))
+        result = checker.check_syllable("གཀར")
+        assert result is not None
+        assert result["severity"] == "error"
+        assert result["corpus_hit"] is True
+
+    def test_corpus_hit_none_when_dictionary_unavailable(self):
+        """When no dictionary is loaded, corpus_hit should be None."""
+        checker = TibetanSpellChecker(dictionary=unavailable_dictionary())
+        result = checker.check_syllable("གཀར")
+        assert result is not None
+        assert result["corpus_hit"] is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 skipped when dictionary unavailable
+# ---------------------------------------------------------------------------
+
+class TestDictionaryUnavailable:
+    def test_no_unknown_word_errors_without_corpus(self):
+        """Without a corpus, Phase 2 is silently skipped — no false positives."""
+        checker = TibetanSpellChecker(dictionary=unavailable_dictionary())
+        # ཡིབ is structurally valid and not in any corpus, but no corpus = no warning
+        result = checker.check_syllable("ཡིབ")
+        assert result is None
+
+    def test_phase1_errors_still_fire_without_corpus(self):
+        """Phase 1 structural checks are unaffected by dictionary availability."""
+        checker = TibetanSpellChecker(dictionary=unavailable_dictionary())
+        result = checker.check_syllable("གཀར")
+        assert result is not None
+        assert result["error_type"] != "unknown_word"
+
+    def test_check_text_without_corpus_matches_phase1_only(self):
+        """Full text check without corpus produces same results as Phase 1."""
+        checker_no_dict = TibetanSpellChecker(dictionary=unavailable_dictionary())
+        # Import original checker for comparison
+        from app.spellcheck.engine import TibetanSpellChecker as Checker
+
+        # Both should return the same structural errors on invalid text
+        text = "གཀར་བོད་"
+        errors_no_dict = [
+            e for e in checker_no_dict.check_text(text)
+            if e["error_type"] != "non_tibetan_skipped"
+        ]
+        # One structural error (གཀར), བོད skipped (no corpus)
+        assert len(errors_no_dict) == 1
+        assert errors_no_dict[0]["error_type"] != "unknown_word"

--- a/database/migrations/001_add_spelling_reference.sql
+++ b/database/migrations/001_add_spelling_reference.sql
@@ -1,0 +1,34 @@
+-- Migration 001: Add spelling_reference table
+-- Phase 2 — word corpus for dictionary-based spell checking
+--
+-- Apply to an existing database (one that already has the jobs/spell_errors
+-- tables from the initial schema) with:
+--
+--   psql $DATABASE_URL -f database/migrations/001_add_spelling_reference.sql
+--
+-- The docker-compose postgres container and CI both use schema.sql directly
+-- (full create), so this migration is only needed when upgrading a live database.
+--
+-- Future extensions (Phase 3+) hang off this table's primary key:
+--   word_definitions (word_id → spelling_reference.id)  — definitions, part of speech
+--   word_relationships (word_id, related_word_id)       — synonyms, dialect variants
+--   word_etymology (word_id)                            — origin language, root form
+
+CREATE TABLE IF NOT EXISTS spelling_reference (
+    id SERIAL PRIMARY KEY,
+    word TEXT UNIQUE NOT NULL,
+    word_normalized TEXT NOT NULL,
+    source_count INTEGER NOT NULL DEFAULT 1,
+    sources JSONB NOT NULL DEFAULT '[]',
+    confidence_score DECIMAL(3,2),
+    first_seen_in VARCHAR(50),
+    times_seen INTEGER NOT NULL DEFAULT 0,
+    dialect VARCHAR(20),
+    is_sanskrit BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_spelling_ref_word ON spelling_reference(word);
+CREATE INDEX IF NOT EXISTS idx_spelling_ref_word_normalized ON spelling_reference(word_normalized);
+CREATE INDEX IF NOT EXISTS idx_spelling_ref_dialect ON spelling_reference(dialect);
+CREATE INDEX IF NOT EXISTS idx_spelling_ref_confidence ON spelling_reference(confidence_score DESC);

--- a/database/migrations/001_add_spelling_reference.sql
+++ b/database/migrations/001_add_spelling_reference.sql
@@ -20,7 +20,6 @@ CREATE TABLE IF NOT EXISTS spelling_reference (
     word_normalized TEXT NOT NULL,
     source_count INTEGER NOT NULL DEFAULT 1,
     sources JSONB NOT NULL DEFAULT '[]',
-    confidence_score DECIMAL(3,2),
     first_seen_in VARCHAR(50),
     times_seen INTEGER NOT NULL DEFAULT 0,
     dialect VARCHAR(20),

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,6 +1,5 @@
 -- Tibetan Spellchecker Database Schema
 -- PostgreSQL 15+
--- NOTE: Database not used yet - planned for Block 5 (PDF Processing)
 
 -- Jobs table: Track PDF spell check jobs
 CREATE TABLE jobs (
@@ -33,3 +32,28 @@ CREATE TABLE spell_errors (
 CREATE INDEX idx_jobs_status ON jobs(status);
 CREATE INDEX idx_jobs_created_at ON jobs(created_at DESC);
 CREATE INDEX idx_spell_errors_job_id ON spell_errors(job_id);
+
+-- Spelling reference: validated Tibetan word corpus (Phase 2)
+-- Words are stored at the dictionary-entry level (may be multi-syllable).
+-- At runtime the DictionaryService extracts individual syllables from all
+-- entries and builds an in-memory frozenset for O(1) per-syllable lookup.
+-- Future Phase 3+ tables (word_definitions, word_relationships, word_etymology)
+-- will reference this table via spelling_reference.id as a foreign key.
+CREATE TABLE spelling_reference (
+    id SERIAL PRIMARY KEY,
+    word TEXT UNIQUE NOT NULL,           -- original form from source
+    word_normalized TEXT NOT NULL,       -- NFC-normalized form, used for dedup
+    source_count INTEGER NOT NULL DEFAULT 1,
+    sources JSONB NOT NULL DEFAULT '[]', -- e.g. ["thdl", "rangjung_yeshe"]
+    confidence_score DECIMAL(3,2),       -- 0.40–1.00 derived from source_count
+    first_seen_in VARCHAR(50),           -- which source contributed it first
+    times_seen INTEGER NOT NULL DEFAULT 0, -- incremented when found in checked docs
+    dialect VARCHAR(20),                 -- 'amdo', 'u_tsang', NULL = pan-dialectal
+    is_sanskrit BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_spelling_ref_word ON spelling_reference(word);
+CREATE INDEX idx_spelling_ref_word_normalized ON spelling_reference(word_normalized);
+CREATE INDEX idx_spelling_ref_dialect ON spelling_reference(dialect);
+CREATE INDEX idx_spelling_ref_confidence ON spelling_reference(confidence_score DESC);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -45,7 +45,6 @@ CREATE TABLE spelling_reference (
     word_normalized TEXT NOT NULL,       -- NFC-normalized form, used for dedup
     source_count INTEGER NOT NULL DEFAULT 1,
     sources JSONB NOT NULL DEFAULT '[]', -- e.g. ["thdl", "rangjung_yeshe"]
-    confidence_score DECIMAL(3,2),       -- 0.40–1.00 derived from source_count
     first_seen_in VARCHAR(50),           -- which source contributed it first
     times_seen INTEGER NOT NULL DEFAULT 0, -- incremented when found in checked docs
     dialect VARCHAR(20),                 -- 'amdo', 'u_tsang', NULL = pan-dialectal

--- a/frontend/__tests__/pages/spellcheck.test.tsx
+++ b/frontend/__tests__/pages/spellcheck.test.tsx
@@ -147,7 +147,7 @@ describe('SpellCheckPage', () => {
       const words = screen.getAllByText('གཀར')
       expect(words.length).toBeGreaterThan(0)
       expect(screen.getByText('Invalid Prefix Combination')).toBeInTheDocument()
-      expect(screen.getByText(/1 spelling error found/i)).toBeInTheDocument()
+      expect(screen.getByText(/1 error/i)).toBeInTheDocument()
     })
   })
 
@@ -249,7 +249,7 @@ describe('SpellCheckPage', () => {
     await waitFor(() => {
       const words = screen.getAllByText('གཀར')
       expect(words.length).toBeGreaterThan(0)
-      expect(screen.getByText(/1 spelling error found/i)).toBeInTheDocument()
+      expect(screen.getByText(/1 error/i)).toBeInTheDocument()
     })
 
     expect(mockedApi.checkText).toHaveBeenCalledTimes(2)

--- a/frontend/components/spellcheck/ErrorDisplay.tsx
+++ b/frontend/components/spellcheck/ErrorDisplay.tsx
@@ -34,6 +34,11 @@ const SeverityBadge: React.FC<{ severity: string }> = ({ severity }) => {
   )
 }
 
+const errorUnderlineClass = (severity: string): string => {
+  if (severity === 'warning') return 'border-b-2 border-yellow-400 text-yellow-700 cursor-pointer'
+  return 'border-b-2 border-red-500 text-red-700 cursor-pointer'
+}
+
 const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
   text,
   errors,
@@ -57,13 +62,12 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
   // Create a map of error positions for quick lookup
   const errorMap = new Map<number, SpellCheckError>()
   spellingErrors.forEach((error) => {
-    // Mark the entire word as having an error
     for (let i = 0; i < error.word.length; i++) {
       errorMap.set(error.position + i, error)
     }
   })
 
-  // Render text with errors underlined
+  // Render text with errors underlined (red = structural, yellow = unknown word)
   const chars = Array.from(text)
   const elements: React.ReactNode[] = []
   let currentErrorStart = -1
@@ -73,20 +77,18 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
     const error = errorMap.get(i)
 
     if (error && currentError !== error) {
-      // Start of a new error
       if (currentErrorStart >= 0 && currentError) {
-        // Close previous error span
         elements.push(
           <span
             key={`error-${currentErrorStart}`}
             className="relative inline-block group"
           >
-            <span className="border-b-2 border-red-500 text-red-700 cursor-pointer">
+            <span className={errorUnderlineClass(currentError.severity)}>
               {chars.slice(currentErrorStart, i).join('')}
             </span>
             <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
               {formatErrorType(currentError.error_type)}
-              {currentError.message && ` - ${currentError.message}`}
+              {currentError.message && ` — ${currentError.message}`}
             </span>
           </span>
         )
@@ -94,18 +96,17 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
       currentErrorStart = i
       currentError = error
     } else if (!error && currentErrorStart >= 0 && currentError) {
-      // End of error, render error span
       elements.push(
         <span
           key={`error-${currentErrorStart}`}
           className="relative inline-block group"
         >
-          <span className="border-b-2 border-red-500 text-red-700 cursor-pointer">
+          <span className={errorUnderlineClass(currentError.severity)}>
             {chars.slice(currentErrorStart, i).join('')}
           </span>
           <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
             {formatErrorType(currentError.error_type)}
-            {currentError.message && ` - ${currentError.message}`}
+            {currentError.message && ` — ${currentError.message}`}
           </span>
         </span>
       )
@@ -114,41 +115,49 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
     }
 
     if (!error) {
-      // Regular character
       if (chars[i] === '\n') {
         elements.push(<br key={`br-${i}`} />)
       } else {
-        elements.push(
-          <span key={`char-${i}`}>{chars[i]}</span>
-        )
+        elements.push(<span key={`char-${i}`}>{chars[i]}</span>)
       }
     }
   }
 
-  // Handle any remaining error at the end
   if (currentErrorStart >= 0 && currentError) {
     elements.push(
       <span
         key={`error-${currentErrorStart}`}
         className="relative inline-block group"
       >
-        <span className="border-b-2 border-red-500 text-red-700 cursor-pointer">
+        <span className={errorUnderlineClass(currentError.severity)}>
           {chars.slice(currentErrorStart).join('')}
         </span>
         <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
           {formatErrorType(currentError.error_type)}
-          {currentError.message && ` - ${currentError.message}`}
+          {currentError.message && ` — ${currentError.message}`}
         </span>
       </span>
     )
   }
 
   return (
-    <div
-      className="text-2xl leading-loose p-6 bg-white rounded-lg border border-gray-200"
-      style={{ fontFamily: 'Jomolhari, serif' }}
-    >
-      {elements}
+    <div className="space-y-3">
+      <div
+        className="text-2xl leading-loose p-6 bg-white rounded-lg border border-gray-200"
+        style={{ fontFamily: 'Jomolhari, serif' }}
+      >
+        {elements}
+      </div>
+      <div className="flex gap-4 text-xs text-gray-500">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-4 border-b-2 border-red-500" />
+          Structural error
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-4 border-b-2 border-yellow-400" />
+          Not found in word corpus
+        </span>
+      </div>
     </div>
   )
 }
@@ -156,10 +165,12 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ response }) => {
   const { text, errors } = response
 
-  // Separate spelling errors from info messages
+  // Separate structural errors, unknown-word warnings, and info messages
   const spellingErrors = errors.filter(
     (e) => e.severity !== 'info' && e.position >= 0
   )
+  const structuralErrors = spellingErrors.filter((e) => e.severity !== 'warning')
+  const unknownWordWarnings = spellingErrors.filter((e) => e.severity === 'warning')
   const infoMessages = errors.filter((e) => e.severity === 'info')
 
   // Success state: no spelling errors
@@ -221,11 +232,21 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ response }) => {
       <div className="bg-white rounded-lg border border-gray-200 p-4 shadow-sm">
         <div className="flex items-center justify-between">
           <h3 className="text-lg font-semibold text-gray-900">
-            {spellingErrors.length}{' '}
-            {spellingErrors.length === 1
-              ? 'spelling error'
-              : 'spelling errors'}{' '}
-            found
+            {structuralErrors.length > 0 && (
+              <span className="text-red-700">
+                {structuralErrors.length}{' '}
+                {structuralErrors.length === 1 ? 'error' : 'errors'}
+              </span>
+            )}
+            {structuralErrors.length > 0 && unknownWordWarnings.length > 0 && (
+              <span className="text-gray-400 mx-2">/</span>
+            )}
+            {unknownWordWarnings.length > 0 && (
+              <span className="text-yellow-700">
+                {unknownWordWarnings.length}{' '}
+                {unknownWordWarnings.length === 1 ? 'unknown word' : 'unknown words'}
+              </span>
+            )}
           </h3>
           <span className="text-xs text-gray-500">
             Hover over underlined text for details
@@ -262,7 +283,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ response }) => {
           <Card
             key={`${error.position}-${index}`}
             variant="bordered"
-            className="my-0"
+            className={`my-0 border-l-4 ${error.severity === 'warning' ? 'border-l-yellow-400' : 'border-l-red-400'}`}
           >
             <div className="flex flex-col gap-3">
               <div className="flex items-start justify-between">

--- a/frontend/components/spellcheck/__tests__/ErrorDisplay.test.tsx
+++ b/frontend/components/spellcheck/__tests__/ErrorDisplay.test.tsx
@@ -45,7 +45,7 @@ describe('ErrorDisplay', () => {
   it('displays error count', () => {
     render(<ErrorDisplay response={mockResponse} />)
 
-    expect(screen.getByText(/2 spelling errors found/i)).toBeInTheDocument()
+    expect(screen.getByText(/2 errors/i)).toBeInTheDocument()
   })
 
   it('displays singular error count', () => {
@@ -56,7 +56,7 @@ describe('ErrorDisplay', () => {
     }
     render(<ErrorDisplay response={singleErrorResponse} />)
 
-    expect(screen.getByText(/1 spelling error found/i)).toBeInTheDocument()
+    expect(screen.getByText(/1 error/i)).toBeInTheDocument()
   })
 
   it('renders each error with details', () => {
@@ -178,7 +178,7 @@ describe('ErrorDisplay', () => {
     render(<ErrorDisplay response={withInfoResponse} />)
 
     // Should show info message but not count it as spelling error
-    expect(screen.getByText(/1 spelling error found/i)).toBeInTheDocument()
+    expect(screen.getByText(/1 error/i)).toBeInTheDocument()
     expect(screen.getByText(/skipped/i)).toBeInTheDocument()
   })
 })

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -11,6 +11,7 @@ export interface SpellCheckError {
   severity: string
   message?: string
   component?: string
+  corpus_hit?: boolean | null
 }
 
 export interface SpellCheckResponse {
@@ -111,6 +112,7 @@ export interface PDFSpellError {
   severity: string
   message?: string
   component?: string
+  corpus_hit?: boolean | null
 }
 
 export interface PDFResultURLs {

--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,14 @@ services:
         value: https://www.butterdots.com,https://butterdots.com
       - key: DEBUG
         value: "false"
+      # Uncomment and set to enable Phase 2 dictionary lookup in production.
+      # Provision a Render PostgreSQL database first, then paste its Internal
+      # Database URL here (or set it as a secret in the Render dashboard).
+      # - key: DATABASE_URL
+      #   value: postgresql://...
+
+# Uncomment to provision a managed PostgreSQL database on Render.
+# Note: the free plan does not include a database — this will incur a charge.
+# databases:
+#   - name: tibetan-spellcheck-db
+#     plan: starter


### PR DESCRIPTION
## What's in here

Phase 2 of the spellchecker: after a syllable passes all the structural checks,
we now also look it up in a corpus of attested Tibetan words. If it's not there,
it comes back as an `unknown_word` warning — yellow underline, not red — so
learners can distinguish "this is structurally broken" from "we haven't seen
this word before." The corpus is empty in production right now (database not yet
provisioned on Render), so there's no user-facing change yet, but the full
pipeline is wired and tested.

The other piece worth knowing about: every Phase 1 structural error now also
carries a `corpus_hit` flag. If something fails structurally but the syllable is
in the corpus anyway, that's a signal we might have a false positive rule. That
data flows into a structured log line (`spellcheck_result`) on every request
— grep for it and pipe to jq when we want to audit.

Closes #7, closes #9

## Worth a closer look

The `DictionaryService` returns `None` (not `False`) when the corpus isn't
loaded — callers need to distinguish "not in corpus" from "corpus not available."
That distinction is what lets the engine skip the warning gracefully in
production today.

Word segmentation is intentionally not solved here — lookups are per-syllable,
not per-word sequence. Invalid compounds are Phase 3.

## Phase update

This finishes the infrastructure for both issues #7 and #9. Issue #9 is still
marked Blocked on the board because the corpus extractors for THDL and Rangjung
Yeshe aren't implemented yet (licensing TBD). Once a source is confirmed, those
are a few hours of work in `build_corpus.py`. The seed corpus is there for
pipeline testing in the meantime.

## To enable Phase 2 in production

Once ready to wire this up on Render:

1. Provision a Render PostgreSQL database (see commented stubs in `render.yaml`)
2. Run `database/migrations/001_add_spelling_reference.sql` against the production DB
3. Set `DATABASE_URL` as an environment variable on the Render web service
4. Run `python scripts/seed_corpus.py` (or `build_corpus.py` once sources are licensed) to populate the corpus

Until then, Phase 1 structural validation continues to run normally — no user-facing change in production.
