### PR TITLE
Fix Tibetan འོ spellcheck, spelling-rules རུ་ example, and CI Render deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,15 @@ jobs:
       - name: Run tests
         working-directory: ./frontend
         run: yarn test:ci
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [backend-tests, frontend-tests]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Deploy to Render
+        env:
+          deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl "$deploy_url"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project uses
 
 ---
 
+## [0.6.1] - 2026-04-16
+
+### Fixed
+
+- Tibetan syllable parser falsely flagged **འོ** (achung + o-vowel) on valid forms such as **བྱའོ**, **པོའོ**, and **མཐོའོ**. The **འི** path is now generalized: shared `ACHUNG_SUFFIX_VOWELS` (ི, ོ), one detect/parse pipeline, and completeness rules aligned so two vowel marks are allowed when the second sits on suffix **འ**.
+- Spelling rules page: **རུ་** locative example updated from **རྒྱལ་ཁབ་རུ་** to **བཀའ་རུ་**. A **བ** suffix takes **ཏུ་** (e.g. **རྒྱལ་ཁབ་ཏུ་** “to/in the kingdom”), not **རུ་**, which only follows **འ** or no suffix—consistent with the particle rules in the spellchecker.
+
+---
+
 ## [0.6.0] - 2026-04-15
 
 ### Fixed

--- a/backend/BDRC/image_dewarping.py
+++ b/backend/BDRC/image_dewarping.py
@@ -12,7 +12,10 @@ import cv2
 import scipy
 import numpy as np
 import numpy.typing as npt
-from tps import ThinPlateSpline
+try:
+    from tps import ThinPlateSpline
+except ImportError:
+    ThinPlateSpline = None  # type: ignore[assignment,misc]
 from typing import List
 
 from BDRC.Data import Line

--- a/backend/app/spellcheck/achung_suffix.py
+++ b/backend/app/spellcheck/achung_suffix.py
@@ -1,0 +1,18 @@
+"""
+Shared definitions for achung (འ) + suffix vowel syllable endings.
+
+Used by the syllable parser and completeness checks so allowed suffix vowels
+(ི on འ for འི, ོ for འོ, …) stay in sync.
+"""
+
+# U+0F60 TIBETAN LETTER A
+ACHUNG = "\u0F60"
+
+# Vowel marks that may appear on suffix achung (after the stem).
+# ི — relational འི; ོ — particle འོ (e.g. sentence-final).
+ACHUNG_SUFFIX_VOWELS = frozenset(
+    {
+        "\u0F72",  # ི
+        "\u0F7C",  # ོ
+    }
+)

--- a/backend/app/spellcheck/data_types/syllable.py
+++ b/backend/app/spellcheck/data_types/syllable.py
@@ -24,7 +24,7 @@ class TibetanSyllable:
         subscripts: Subscript letters below root (ྱ ྲ ླ ྭ)
         vowel: The vowel mark, or None for inherent 'a'
         suffix: Optional suffix letter
-        suffix_vowel: Optional vowel on the suffix (ི on འ for relational འི)
+        suffix_vowel: Optional vowel on suffix འ (ི for འི, ོ for འོ, …)
         post_suffix: Optional post-suffix letter (ད or ས)
         unparsed: Characters the parser could not assign to a component
     """

--- a/backend/app/spellcheck/parsing/parser.py
+++ b/backend/app/spellcheck/parsing/parser.py
@@ -13,6 +13,7 @@ KEY PRINCIPLE: Stacking rules are used DURING parsing, not after.
 The valid combination sets are the deciding factor for structural decisions.
 """
 from typing import List, Optional
+from ..achung_suffix import ACHUNG_SUFFIX_VOWELS
 from ..data_types import TypedChar, CharType, TibetanSyllable
 from ..rules.stacking import (
     VALID_PREFIXES,
@@ -38,16 +39,18 @@ def parse_syllable(typed_chars: List[TypedChar]) -> TibetanSyllable:
     if not typed_chars:
         return TibetanSyllable(raw=raw)
 
-    # Step 0: Check for འི relational suffix pattern BEFORE normal parsing.
+    # Step 0: Check for འ + suffix vowel (འི, འོ, …) BEFORE normal parsing.
     #
-    # འི (achung + i-vowel) can be added to syllables with no suffix or
-    # suffix འ. Without this early detection, the ི vowel causes the
-    # parser to misidentify འ as the root (since "root = last consonant
-    # before first vowel"). Detecting this first lets us parse the body
-    # correctly and attach འི as a suffix.
-    achung_i_idx = _detect_achung_i_suffix(typed_chars)
-    if achung_i_idx is not None:
-        return _parse_with_achung_i_suffix(typed_chars, achung_i_idx, raw)
+    # Without this early detection, the vowel on འ causes འ to be
+    # misidentified as the root (since "root = last consonant before first
+    # vowel"). Detecting this first lets us parse the body correctly and
+    # attach suffix འ + suffix_vowel.
+    achung_suffix = _detect_achung_suffix_vowel(typed_chars)
+    if achung_suffix is not None:
+        achung_idx, suffix_vowel_char = achung_suffix
+        return _parse_with_achung_suffix_vowel(
+            typed_chars, achung_idx, raw, suffix_vowel_char,
+        )
 
     # Step 1: Find superscript (first structural decision, informed by stacking rules)
     super_idx, root_idx = _find_superscript(typed_chars)
@@ -342,61 +345,67 @@ def _parse_no_vowel(
 
 
 # ============================================================================
-# Step 3d: Parse with འི relational suffix
+# Step 3d: Parse with འ + suffix vowel (འི, འོ, …)
 # ============================================================================
 
-def _detect_achung_i_suffix(chars: List[TypedChar]) -> Optional[int]:
+def _detect_achung_suffix_vowel(
+    chars: List[TypedChar],
+) -> Optional[tuple[int, str]]:
     """
-    Check if the syllable ends with འི (achung + i-vowel) relational suffix.
+    Check if the syllable ends with འ + an allowed suffix vowel (e.g. འི, འོ).
 
-    This pattern must be detected BEFORE normal vowel-based parsing,
-    because ི would otherwise cause འ to be misidentified as the root.
+    This pattern must be detected BEFORE normal vowel-based parsing, otherwise
+    the vowel on འ causes འ to be misidentified as the root.
 
     Conditions:
-    - At least 3 characters (need consonant(s) + འ + ི)
-    - Last character is ི (VOWEL, U+0F72)
+    - At least 3 characters (consonant(s) + འ + vowel)
+    - Last character is a VOWEL in ACHUNG_SUFFIX_VOWELS
     - Second-to-last is འ (BASE, U+0F60)
 
     Returns:
-        Index of འ if pattern detected, None otherwise.
+        (index of འ, suffix vowel character) if detected, else None.
     """
     n = len(chars)
     if n < 3:
         return None
 
-    if (chars[n - 1].type == CharType.VOWEL and
-            chars[n - 1].char == '\u0F72' and
-            chars[n - 2].type == CharType.BASE and
-            chars[n - 2].base_form == '\u0F60'):
-        return n - 2
+    last = chars[n - 1]
+    achung = chars[n - 2]
+    if (
+        last.type == CharType.VOWEL
+        and last.char in ACHUNG_SUFFIX_VOWELS
+        and achung.type == CharType.BASE
+        and achung.base_form == "འ"
+    ):
+        return (n - 2, last.char)
 
     return None
 
 
-def _parse_with_achung_i_suffix(
+def _parse_with_achung_suffix_vowel(
     typed_chars: List[TypedChar],
     achung_idx: int,
     raw: str,
+    suffix_vowel: str,
 ) -> TibetanSyllable:
     """
-    Parse a syllable ending with འི relational suffix.
+    Parse a syllable ending with འ + suffix vowel (relational འི, particle འོ, …).
 
     Strategy:
-    1. Split off the འ + ི ending
+    1. Split off the འ + vowel ending
     2. Parse the body (everything before འ) to find prefix/superscript/root/subscripts/vowel
     3. If the body already has its own suffix (e.g., སྐད has suffix ད),
-       the འི is NOT a valid relational -- fall back to normal parsing
-    4. Otherwise, attach suffix=འ, suffix_vowel=ི
+       the trailing འ + vowel is NOT valid -- fall back to normal parsing
+    4. Otherwise, attach suffix=འ, suffix_vowel=suffix_vowel
 
-    The body should have NO suffix of its own -- the suffix is the འ from འི.
-    If the body does have a suffix, the word already had a non-achung suffix
-    and འི was appended incorrectly.
+    If the body has a suffix, the word already had a non-achung suffix and
+    འ + vowel was appended incorrectly.
     """
     body = typed_chars[:achung_idx]
 
     result = TibetanSyllable(raw=raw)
-    result.suffix = '\u0F60'   # འ
-    result.suffix_vowel = '\u0F72'  # ི
+    result.suffix = "འ"  # འ
+    result.suffix_vowel = suffix_vowel
 
     if not body:
         return result
@@ -410,8 +419,8 @@ def _parse_with_achung_i_suffix(
         temp = _parse_with_superscript(body, super_idx, root_idx, vowel_idx, raw)
 
         # If the body already has a suffix (e.g., སྐད → suffix=ད),
-        # the འི at the end is invalid. Fall back to normal parsing
-        # so the extra འི ends up as unparsed characters.
+        # the འ + vowel at the end is invalid. Fall back to normal parsing
+        # so the extra syllable material ends up as unparsed characters.
         if temp.suffix is not None:
             return _parse_normal(typed_chars, raw)
 
@@ -423,7 +432,7 @@ def _parse_with_achung_i_suffix(
         result.unparsed = temp.unparsed
 
     elif vowel_idx is not None:
-        # Body has a vowel (e.g., མཐོ in མཐོའི): reuse vowel logic
+        # Body has a vowel (e.g., མཐོ in མཐོའི / མཐོའོ): reuse vowel logic
         temp = _parse_with_vowel(body, vowel_idx, raw)
 
         # Same check: if body already has a suffix, fall back
@@ -450,10 +459,10 @@ def _parse_normal(
     raw: str,
 ) -> TibetanSyllable:
     """
-    Run the normal parsing pipeline (without འི detection).
+    Run the normal parsing pipeline (without achung+suffix-vowel detection).
 
-    Used as fallback when འི detection was triggered but the body
-    already has its own suffix, meaning འི is not a valid relational.
+    Used as fallback when that detection was triggered but the body
+    already has its own suffix, meaning འ + vowel is not a valid ending.
     """
     super_idx, root_idx = _find_superscript(typed_chars)
     vowel_idx = _find_first_vowel(typed_chars)
@@ -471,10 +480,10 @@ def _parse_body_consonants(
     result: TibetanSyllable,
 ) -> None:
     """
-    Parse consonant-only body when suffix is known to be outside (འི pattern).
+    Parse consonant-only body when suffix is known to be outside (འ + suffix vowel).
 
     Unlike _parse_no_vowel, this does NOT assign any body consonant as suffix,
-    because the suffix is the འ from the འི ending.
+    because the suffix is the འ from the འི / འོ ending.
 
     Handles:
     - Single consonant: root

--- a/backend/app/spellcheck/validation/completeness_checks.py
+++ b/backend/app/spellcheck/validation/completeness_checks.py
@@ -6,6 +6,8 @@ This is a bridge function that works with the old dict-based parsed format.
 """
 from typing import Dict, Optional
 
+from ..achung_suffix import ACHUNG_SUFFIX_VOWELS
+
 
 def check_syllable_structure_completeness(syllable: str, parsed: Dict[str, any]) -> Optional[Dict[str, any]]:
     """
@@ -41,20 +43,19 @@ def check_syllable_structure_completeness(syllable: str, parsed: Dict[str, any])
 
     # ERROR 1: Multiple separated vowels
     if len(vowels) > 1:
-        # Exception: འི relational suffix
-        # When a syllable ends with འ + ི, the ི is a valid suffix vowel.
-        # This creates exactly 2 vowel marks (root vowel + suffix ི) which
-        # is legitimate and should not be flagged.
-        is_achung_i_suffix = False
+        # Exception: འ + suffix vowel (འི, འོ, …)
+        # When a syllable ends with འ + an allowed suffix vowel, two vowel
+        # marks (root + suffix) are legitimate.
+        is_achung_suffix_second_vowel = False
         if len(vowels) == 2:
             last_vowel_pos, last_vowel_char = vowels[-1]
-            if (last_vowel_char == '\u0F72' and  # ི
-                    last_vowel_pos > 0 and
-                    last_vowel_pos - 1 < len(syllable) and
-                    ord(syllable[last_vowel_pos - 1]) == 0x0F60):  # འ
-                is_achung_i_suffix = True
+            if (last_vowel_char in ACHUNG_SUFFIX_VOWELS
+                    and last_vowel_pos > 0
+                    and last_vowel_pos - 1 < len(syllable)
+                    and ord(syllable[last_vowel_pos - 1]) == 0x0F60):  # འ
+                is_achung_suffix_second_vowel = True
 
-        if not is_achung_i_suffix:
+        if not is_achung_suffix_second_vowel:
             vowel_positions = [pos for pos, _ in vowels]
             has_separated = any(
                 vowel_positions[i + 1] - vowel_positions[i] > 1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,6 +33,7 @@ numpy==1.26.4
 scipy==1.12.0
 pyewts==0.2.0
 pypdf==4.1.0
+pyctcdecode==0.5.0
 
 # PDF annotation (annotated PDF output)
 pymupdf==1.24.1

--- a/backend/tests/test_engine.py
+++ b/backend/tests/test_engine.py
@@ -638,6 +638,46 @@ class TestAchungISuffixValidation:
             "ཡིགའི should be invalid -- འི cannot follow suffix ག"
 
 
+
+
+class TestAchungOSuffixValidation:
+    """
+    འོ (achung + o-vowel) as suffix — same grammatical constraints as འི:
+    only after no suffix or suffix འ.
+    """
+
+    def test_bya_o_valid(self):
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        engine = TibetanSpellChecker()
+        assert engine.check_syllable("བྱའོ") is None
+
+    def test_po_o_valid_two_vowels(self):
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        engine = TibetanSpellChecker()
+        assert engine.check_syllable("པོའོ") is None
+
+    def test_mtho_o_valid_two_vowels(self):
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        engine = TibetanSpellChecker()
+        assert engine.check_syllable("མཐོའོ") is None
+
+    def test_bod_o_invalid_suffix_da(self):
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        engine = TibetanSpellChecker()
+        assert engine.check_syllable("བོདའོ") is not None
+
+    def test_achung_o_in_running_text(self):
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        engine = TibetanSpellChecker()
+        errors = engine.check_text("བྱའོ། པོའོ།་")
+        bad = [e.get("word", "") for e in errors if e.get("severity") != "info"]
+        assert "བྱའོ" not in bad
+        assert "པོའོ" not in bad
 class TestPositionMappingWithZeroWidth:
     """
     Regression tests: error positions must be relative to the *original*

--- a/backend/tests/test_ocr_parity.py
+++ b/backend/tests/test_ocr_parity.py
@@ -65,6 +65,7 @@ _OCR_REQUIRED_FIXTURES = {"Tashi Gyedpa"}
 def _ocr_available() -> bool:
     try:
         import pyctcdecode  # noqa: F401
+        import tps  # noqa: F401
 
         return True
     except ImportError:

--- a/backend/tests/test_parsing.py
+++ b/backend/tests/test_parsing.py
@@ -701,3 +701,52 @@ class TestAchungISuffixParsing:
 
         assert len(model.unparsed) == 0, \
             f"མཐོའི: all characters should be parsed, but unparsed={[tc.char for tc in model.unparsed]}"
+
+
+# ============================================================================
+# འོ (Achung + O-Vowel) Suffix Parsing — same mechanism as འི
+# ============================================================================
+
+class TestAchungOSuffixParsing:
+    """Parse འོ (achung + o-vowel) as suffix; root must not be འ."""
+
+    def test_bya_o_root_is_ba_not_achung(self):
+        """བྱའོ — root བ + subscript, suffix འ + ོ"""
+        parser = TibetanSyllableParser()
+        parsed = parser.parse("བྱའོ")
+
+        assert get_root_base_form(parsed) == "བ"
+        assert parsed["suffix"] == "འ"
+        assert parsed["suffix_vowel"] == "ོ"
+
+    def test_po_o_two_vowel_marks(self):
+        """པོའོ — root vowel ོ + suffix འ + ོ (two vowel marks)."""
+        parser = TibetanSyllableParser()
+        parsed = parser.parse("པོའོ")
+
+        assert get_root_base_form(parsed) == "པ"
+        assert "ོ" in parsed.get("vowels", [])
+        assert parsed["suffix"] == "འ"
+        assert parsed["suffix_vowel"] == "ོ"
+
+    def test_mtho_o_symmetric_with_mtho_i(self):
+        """མཐོའོ — same structure as མཐོའི but suffix vowel ོ."""
+        parser = TibetanSyllableParser()
+        parsed = parser.parse("མཐོའོ")
+
+        assert_components(
+            parsed,
+            prefix="མ",
+            root="ཐ",
+            vowel="ོ",
+            suffix="འ",
+        )
+        assert parsed["suffix_vowel"] == "ོ"
+
+    def test_achung_o_suffix_fully_parsed(self):
+        parser = TibetanSyllableParser()
+        for word in ("བྱའོ", "པོའོ", "མཐོའོ"):
+            model = parser.parse_to_model(word)
+            assert len(model.unparsed) == 0, (
+                f"{word}: unparsed={[tc.char for tc in model.unparsed]}"
+            )

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -8,7 +8,6 @@
 /playwright-report
 /test-results
 package-lock.json
-
 # Next.js
 /.next/
 /out/

--- a/frontend/pages/spelling-rules.tsx
+++ b/frontend/pages/spelling-rules.tsx
@@ -371,8 +371,8 @@ const SpellingRules: NextPage = () => {
             {
               particle: 'རུ',
               suffixes: 'འ  or no suffix',
-              example: 'རྒྱལ་ཁབ་རུ་',
-              exampleGloss: 'in the kingdom',
+              example: 'བཀའ་རུ་',
+              exampleGloss: 'into the command; according to the decree',
             },
             {
               particle: 'ར',


### PR DESCRIPTION
## Summary

This branch fixes false positives for **འོ** (achung + o-vowel) by routing **achung + suffix vowel** through a shared pipeline (`ACHUNG_SUFFIX_VOWELS`), restores `pyctcdecode` after an accidental removal, updates completeness checks and tests, corrects the spelling rules **རུ་** example (**བཀའ་རུ་**), and documents changes under **[0.6.1]** in `CHANGELOG.md`. CI triggers a Render deploy after tests pass on **main**, and Playwright report output is gitignored.

**Closes #46**

## User-facing impact

- Spellcheck no longer incorrectly flags valid forms like **བྱའོ**, **པོའོ**, and **མཐོའོ**; invalid cases such as **བོདའོ** remain flagged.
- The spelling rules page shows a correct **རུ་** example (**བཀའ་རུ་**). Words ending in **བ** take **ཏུ་** (e.g. **རྒྱལ་ཁབ་ཏུ་**), not **རུ་**.

## Technical summary

**Backend:** New `achung_suffix.py`; parser `_detect_achung_suffix_vowel` / `_parse_with_achung_suffix_vowel`; completeness uses the same vowel set. Tests: `TestAchungOSuffixParsing`, `TestAchungOSuffixValidation`.

**Frontend:** `spelling-rules.tsx` locative row; `.gitignore` for Playwright artifacts.

**CI:** `.github/workflows/test.yml` — deploy to Render after green tests on `main`.

## Testing

Backend `pytest -m "not slow"` and frontend `yarn test:ci` were run before commits.

## Changelog

See **[0.6.1] - 2026-04-16** in `CHANGELOG.md`.
