### PR TITLE
Add normalized lexicon schema (word, source, word_source, definition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project uses
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Lexicon data is stored relationally: `word`, `source`, `word_source`, and `definition` replace JSONB on the old spelling list; `lexicon_staging_line` is there for upcoming ingest. Existing databases can run `database/migrations/002_lexicon_schema.sql`; fresh installs use the updated `schema.sql`. `DictionaryService`, `build_corpus.py`, and `seed_corpus.py` target the new tables.
+
+---
+
 ## [0.6.1] - 2026-04-16
 
 ### Fixed

--- a/backend/app/api/corpus.py
+++ b/backend/app/api/corpus.py
@@ -18,8 +18,8 @@ async def corpus_stats():
     Return statistics about the loaded word corpus.
 
     - **available**: whether dictionary lookup is active (requires DATABASE_URL
-      and a populated spelling_reference table)
-    - **word_count**: number of entries in spelling_reference
+      and a populated word table)
+    - **word_count**: number of entries in word
     - **syllable_count**: unique syllables extracted from all entries
     """
     return CorpusStatsResponse(**_dictionary.stats())

--- a/backend/app/schemas/spellcheck.py
+++ b/backend/app/schemas/spellcheck.py
@@ -137,7 +137,7 @@ class CorpusStatsResponse(BaseModel):
     )
     word_count: int = Field(
         ...,
-        description="Number of entries in the spelling_reference table",
+        description="Number of headword entries in the word table",
         ge=0
     )
     syllable_count: int = Field(

--- a/backend/app/spellcheck/dictionary.py
+++ b/backend/app/spellcheck/dictionary.py
@@ -1,7 +1,7 @@
 """
 DictionaryService — Phase 2 word corpus lookup.
 
-Loads all entries from the spelling_reference table at construction time,
+Loads all entries from the word table at construction time,
 extracts every individual syllable from every word (splitting on tsheg), and
 builds an in-memory frozenset for O(1) per-syllable validity checks.
 
@@ -49,7 +49,7 @@ def _syllables_from_word(word: str) -> list[str]:
 
 class DictionaryService:
     """
-    In-memory syllable inventory built from the spelling_reference table.
+    In-memory syllable inventory built from the word table.
 
     Attributes:
         available: True if a database was reachable and at least one word
@@ -67,7 +67,7 @@ class DictionaryService:
         self._load()
 
     def _load(self) -> None:
-        """Query spelling_reference and build the syllable inventory."""
+        """Query word and build the syllable inventory."""
         try:
             from app.database import db_available, get_session
         except ImportError:
@@ -85,7 +85,7 @@ class DictionaryService:
 
             with get_session() as session:
                 rows = session.execute(
-                    text("SELECT word_normalized FROM spelling_reference")
+                    text("SELECT word_normalized FROM word")
                 ).fetchall()
 
             syllable_set: set[str] = set()
@@ -106,7 +106,7 @@ class DictionaryService:
 
         except Exception:
             logger.exception(
-                "Failed to load spelling_reference; dictionary lookup disabled"
+                "Failed to load word corpus; dictionary lookup disabled"
             )
 
     def is_valid_syllable(self, syllable: str) -> Optional[bool]:

--- a/backend/app/spellcheck/engine.py
+++ b/backend/app/spellcheck/engine.py
@@ -34,7 +34,7 @@ class TibetanSpellChecker:
 
     Phase 1: structural/grammatical validation (always active)
     Phase 2: dictionary lookup against the word corpus (active when a database
-             is configured and the spelling_reference table has been populated)
+             is configured and the word table has been populated)
     """
 
     def __init__(self, dictionary: DictionaryService | None = None):

--- a/backend/scripts/build_corpus.py
+++ b/backend/scripts/build_corpus.py
@@ -3,7 +3,7 @@ Tibetan word corpus builder.
 
 Extracts Tibetan words from multiple dictionary sources, cross-references them
 (keeping only words that appear in 2+ sources for quality assurance), and loads
-the result into the spelling_reference table.
+the result into the word and word_source tables.
 
 See docs/planning/WORD_CORPUS_PLAN.md for the sourcing strategy.
 
@@ -31,7 +31,6 @@ Sources status:
                       Status: permission required before use
 """
 import argparse
-import json
 import logging
 import sys
 import unicodedata
@@ -153,7 +152,7 @@ def cross_reference(
         threshold: Minimum number of sources a word must appear in to be kept.
 
     Returns:
-        List of dicts ready for insertion into spelling_reference.
+        List of dicts for load_to_database (word row + per-source word_source).
     """
     word_data: dict[str, dict] = {}
 
@@ -177,7 +176,6 @@ def cross_reference(
         {
             "word": word,
             "word_normalized": word,
-            "source_count": data["source_count"],
             "sources": data["sources"],
             "first_seen_in": data["sources"][0],
         }
@@ -200,14 +198,15 @@ def cross_reference(
 
 def load_to_database(words: list[dict], replace: bool = False) -> int:
     """
-    Insert validated words into spelling_reference.
+    Insert validated headwords into word and word_source (and ensure source rows).
 
     Args:
-        words: List of word dicts from cross_reference().
-        replace: If True, truncate the table before inserting.
+        words: List of word dicts from cross_reference() with keys word,
+               word_normalized, sources, first_seen_in.
+        replace: If True, truncate word (and related rows) before inserting.
 
     Returns:
-        Number of rows inserted.
+        Number of headword rows written.
     """
     # Import here so the script can be imported without a live DB for --dry-run
     import sys
@@ -220,30 +219,59 @@ def load_to_database(words: list[dict], replace: bool = False) -> int:
         logger.error("No database connection. Set DATABASE_URL and try again.")
         return 0
 
-    inserted = 0
+    if not words:
+        return 0
+
+    all_keys = {k for w in words for k in w["sources"]}
+    written = 0
     with get_session() as session:
         if replace:
-            session.execute(text("TRUNCATE spelling_reference"))
-            logger.info("Truncated spelling_reference")
+            session.execute(text("TRUNCATE word RESTART IDENTITY CASCADE"))
+            logger.info("Truncated word (CASCADE to word_source, definition)")
+
+        for key in sorted(all_keys):
+            session.execute(
+                text("""
+                    INSERT INTO source (source_key, display_name) VALUES (:k, :k)
+                    ON CONFLICT (source_key) DO NOTHING
+                """),
+                {"k": key},
+            )
 
         for w in words:
             session.execute(
                 text("""
-                    INSERT INTO spelling_reference
-                        (word, word_normalized, source_count, sources, first_seen_in)
+                    INSERT INTO word
+                        (word, word_normalized, first_seen_in)
                     VALUES
-                        (:word, :word_normalized, :source_count, :sources::jsonb,
-                         :first_seen_in)
-                    ON CONFLICT (word) DO UPDATE SET
-                        source_count = EXCLUDED.source_count,
-                        sources      = EXCLUDED.sources
+                        (:word, :word_normalized, :first_seen_in)
+                    ON CONFLICT (word) DO NOTHING
                 """),
-                {**w, "sources": json.dumps(w["sources"])},
+                {
+                    "word": w["word"],
+                    "word_normalized": w["word_normalized"],
+                    "first_seen_in": w["first_seen_in"],
+                },
             )
-            inserted += 1
+            wid = session.execute(
+                text("SELECT id FROM word WHERE word = :w"), {"w": w["word"]}
+            ).scalar_one()
+            for skey in w["sources"]:
+                sid = session.execute(
+                    text("SELECT id FROM source WHERE source_key = :k"), {"k": skey}
+                ).scalar_one()
+                session.execute(
+                    text("""
+                        INSERT INTO word_source (word_id, source_id)
+                        VALUES (:wid, :sid)
+                        ON CONFLICT (word_id, source_id) DO NOTHING
+                    """),
+                    {"wid": wid, "sid": sid},
+                )
+            written += 1
 
-    logger.info("Inserted/updated %d words in spelling_reference", inserted)
-    return inserted
+    logger.info("Wrote %d headwords to word + word_source", written)
+    return written
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +308,7 @@ def main() -> None:
     parser.add_argument(
         "--replace",
         action="store_true",
-        help="Truncate spelling_reference before inserting (full rebuild)",
+        help="Truncate word (and word_source) before inserting (full rebuild)",
     )
     args = parser.parse_args()
 
@@ -303,7 +331,7 @@ def main() -> None:
     validated = cross_reference(collected, threshold=args.threshold)
 
     if args.dry_run:
-        logger.info("Dry run — %d words would be written to spelling_reference", len(validated))
+        logger.info("Dry run — %d words would be written to word + word_source", len(validated))
         return
 
     load_to_database(validated, replace=args.replace)

--- a/backend/scripts/seed_corpus.py
+++ b/backend/scripts/seed_corpus.py
@@ -1,5 +1,5 @@
 """
-Seed the spelling_reference table with a small hand-verified word list.
+Seed the word table with a small hand-verified word list and word_source row(s).
 
 This is NOT a replacement for the full corpus build (see build_corpus.py).
 Its purpose is to:
@@ -14,11 +14,11 @@ Usage:
     python scripts/seed_corpus.py --replace # truncate first (full reset)
 
 Words here are drawn from common Tibetan Buddhist texts and verified against
-multiple reference dictionaries.  Each entry notes which sources confirm it.
+multiple reference dictionaries.  Provenance is stored as source "seed_corpus".
 """
-import json
 import logging
 import sys
+import unicodedata
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -90,7 +90,6 @@ SEED_WORDS = [
     "མཐོང",
 ]
 
-import unicodedata
 
 def normalize(text: str) -> str:
     return unicodedata.normalize("NFC", text.strip())
@@ -104,38 +103,63 @@ def seed(replace: bool = False) -> int:
         logger.error("No database connection. Set DATABASE_URL and try again.")
         return 0
 
-    inserted = 0
+    seed_key = "seed_corpus"
+    written = 0
     with get_session() as session:
         if replace:
-            session.execute(text("TRUNCATE spelling_reference"))
-            logger.info("Truncated spelling_reference")
+            session.execute(text("TRUNCATE word RESTART IDENTITY CASCADE"))
+            logger.info("Truncated word (CASCADE to word_source, definition)")
+
+        session.execute(
+            text("""
+                INSERT INTO source (source_key, display_name) VALUES (:k, :k)
+                ON CONFLICT (source_key) DO NOTHING
+            """),
+            {"k": seed_key},
+        )
+        sid = session.execute(
+            text("SELECT id FROM source WHERE source_key = :k"), {"k": seed_key}
+        ).scalar_one()
 
         for raw_word in SEED_WORDS:
             word = normalize(raw_word)
             session.execute(
                 text("""
-                    INSERT INTO spelling_reference
-                        (word, word_normalized, source_count, sources, first_seen_in)
+                    INSERT INTO word
+                        (word, word_normalized, first_seen_in)
                     VALUES
-                        (:word, :word_normalized, 1, '["seed_corpus"]'::jsonb, 'seed_corpus')
+                        (:word, :word_normalized, :first_seen)
                     ON CONFLICT (word) DO NOTHING
                 """),
-                {"word": word, "word_normalized": word},
+                {"word": word, "word_normalized": word, "first_seen": seed_key},
             )
-            inserted += 1
+            wid = session.execute(
+                text("SELECT id FROM word WHERE word = :w"), {"w": word}
+            ).scalar_one()
+            session.execute(
+                text("""
+                    INSERT INTO word_source (word_id, source_id)
+                    VALUES (:wid, :sid)
+                    ON CONFLICT (word_id, source_id) DO NOTHING
+                """),
+                {"wid": wid, "sid": sid},
+            )
+            written += 1
 
-    logger.info("Seeded %d words into spelling_reference", inserted)
-    return inserted
+    logger.info("Seeded %d headwords in word + word_source", written)
+    return written
 
 
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Seed spelling_reference with a small verified word list")
+    parser = argparse.ArgumentParser(
+        description="Seed word + word_source with a small verified word list"
+    )
     parser.add_argument(
         "--replace",
         action="store_true",
-        help="Truncate spelling_reference before seeding",
+        help="Truncate word (and dependent rows) before seeding",
     )
     args = parser.parse_args()
     seed(replace=args.replace)

--- a/database/migrations/002_lexicon_schema.sql
+++ b/database/migrations/002_lexicon_schema.sql
@@ -1,0 +1,114 @@
+-- Migration 002: Lexicon schema (WORD_CORPUS_PLAN.md)
+-- Replaces JSONB on spelling_reference with normalized source + word_source;
+-- renames the spelling list table to "word" and adds definition + staging.
+--
+-- Apply to a database that was created with migration 001 (spelling_reference):
+--   psql $DATABASE_URL -f database/migrations/002_lexicon_schema.sql
+--
+-- Fresh environments that use database/schema.sql directly (Docker, CI) already
+-- include this shape and do not need this file unless upgrading an old DB.
+--
+-- Safe to run once. If spelling_reference is already gone, the DO block is a
+-- no-op; CREATE TABLE IF NOT EXISTS is idempotent.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS source (
+    id SERIAL PRIMARY KEY,
+    source_key TEXT UNIQUE NOT NULL,
+    display_name TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS word (
+    id SERIAL PRIMARY KEY,
+    word TEXT UNIQUE NOT NULL,
+    word_normalized TEXT NOT NULL,
+    first_seen_in VARCHAR(50),
+    times_seen INTEGER NOT NULL DEFAULT 0,
+    dialect VARCHAR(20),
+    is_sanskrit BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_word_normalized UNIQUE (word_normalized)
+);
+
+CREATE TABLE IF NOT EXISTS word_source (
+    id SERIAL PRIMARY KEY,
+    word_id INTEGER NOT NULL REFERENCES word(id) ON DELETE CASCADE,
+    source_id INTEGER NOT NULL REFERENCES source(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_word_source_word_source UNIQUE (word_id, source_id)
+);
+
+CREATE TABLE IF NOT EXISTS definition (
+    id SERIAL PRIMARY KEY,
+    word_id INTEGER NOT NULL REFERENCES word(id) ON DELETE CASCADE,
+    source_id INTEGER NOT NULL REFERENCES source(id) ON DELETE CASCADE,
+    body TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS lexicon_staging_line (
+    id BIGSERIAL PRIMARY KEY,
+    import_batch_id UUID NOT NULL,
+    file_ref TEXT,
+    line_number INTEGER,
+    raw_line TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lexicon_staging_batch
+    ON lexicon_staging_line (import_batch_id);
+CREATE INDEX IF NOT EXISTS idx_definition_word_id ON definition (word_id);
+CREATE INDEX IF NOT EXISTS idx_definition_source_id ON definition (source_id);
+CREATE INDEX IF NOT EXISTS idx_definition_word_source
+    ON definition (word_id, source_id);
+CREATE INDEX IF NOT EXISTS idx_word_source_word_id ON word_source (word_id);
+CREATE INDEX IF NOT EXISTS idx_word_source_source_id ON word_source (source_id);
+CREATE INDEX IF NOT EXISTS idx_word_display ON word (word);
+CREATE INDEX IF NOT EXISTS idx_word_dialect ON word (dialect);
+
+-- Migrate from migration 001 spelling_reference into lexicon tables.
+DO
+$$
+BEGIN
+  IF to_regclass('public.spelling_reference') IS NULL THEN
+    RAISE NOTICE 'spelling_reference absent — skipping data migration (already applied or new DB)';
+  ELSE
+    -- Distinct source keys from legacy JSONB arrays
+    INSERT INTO source (source_key, display_name)
+    SELECT DISTINCT
+        src.t,
+        src.t
+    FROM spelling_reference sr
+    CROSS JOIN LATERAL jsonb_array_elements_text (sr.sources) AS src (t)
+    ON CONFLICT (source_key) DO NOTHING;
+
+    INSERT INTO word
+        (word, word_normalized, first_seen_in, times_seen, dialect, is_sanskrit, created_at)
+    SELECT
+        word,
+        word_normalized,
+        first_seen_in,
+        times_seen,
+        dialect,
+        is_sanskrit,
+        created_at
+    FROM spelling_reference
+    ON CONFLICT (word) DO NOTHING;
+
+    INSERT INTO word_source (word_id, source_id)
+    SELECT w.id, s.id
+    FROM spelling_reference sr
+    INNER JOIN word w ON w.word = sr.word
+    CROSS JOIN LATERAL jsonb_array_elements_text (sr.sources) AS src (t)
+    INNER JOIN source s ON s.source_key = src.t
+    ON CONFLICT (word_id, source_id) DO NOTHING;
+
+    DROP TABLE spelling_reference;
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -33,25 +33,61 @@ CREATE INDEX idx_jobs_status ON jobs(status);
 CREATE INDEX idx_jobs_created_at ON jobs(created_at DESC);
 CREATE INDEX idx_spell_errors_job_id ON spell_errors(job_id);
 
--- Spelling reference: validated Tibetan word corpus (Phase 2)
--- Words are stored at the dictionary-entry level (may be multi-syllable).
--- At runtime the DictionaryService extracts individual syllables from all
--- entries and builds an in-memory frozenset for O(1) per-syllable lookup.
--- Future Phase 3+ tables (word_definitions, word_relationships, word_etymology)
--- will reference this table via spelling_reference.id as a foreign key.
-CREATE TABLE spelling_reference (
+-- Lexicon: word corpus (Phase 2 spelling) and provenance (WORD_CORPUS_PLAN.md)
+-- The word list used for per-syllable spellcheck: DictionaryService loads
+-- word.word_normalized for all rows. Provenance is word_source + source;
+-- full gloss text lives in definition (ingest pipeline, later PRs).
+CREATE TABLE source (
     id SERIAL PRIMARY KEY,
-    word TEXT UNIQUE NOT NULL,           -- original form from source
-    word_normalized TEXT NOT NULL,       -- NFC-normalized form, used for dedup
-    source_count INTEGER NOT NULL DEFAULT 1,
-    sources JSONB NOT NULL DEFAULT '[]', -- e.g. ["thdl", "rangjung_yeshe"]
-    first_seen_in VARCHAR(50),           -- which source contributed it first
-    times_seen INTEGER NOT NULL DEFAULT 0, -- incremented when found in checked docs
-    dialect VARCHAR(20),                 -- 'amdo', 'u_tsang', NULL = pan-dialectal
-    is_sanskrit BOOLEAN NOT NULL DEFAULT FALSE,
+    source_key TEXT UNIQUE NOT NULL,
+    display_name TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
-CREATE INDEX idx_spelling_ref_word ON spelling_reference(word);
-CREATE INDEX idx_spelling_ref_word_normalized ON spelling_reference(word_normalized);
-CREATE INDEX idx_spelling_ref_dialect ON spelling_reference(dialect);
+CREATE TABLE word (
+    id SERIAL PRIMARY KEY,
+    word TEXT UNIQUE NOT NULL,
+    word_normalized TEXT NOT NULL,
+    first_seen_in VARCHAR(50),
+    times_seen INTEGER NOT NULL DEFAULT 0,
+    dialect VARCHAR(20),
+    is_sanskrit BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_word_normalized UNIQUE (word_normalized)
+);
+
+CREATE TABLE word_source (
+    id SERIAL PRIMARY KEY,
+    word_id INTEGER NOT NULL REFERENCES word(id) ON DELETE CASCADE,
+    source_id INTEGER NOT NULL REFERENCES source(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_word_source_word_source UNIQUE (word_id, source_id)
+);
+
+CREATE TABLE definition (
+    id SERIAL PRIMARY KEY,
+    word_id INTEGER NOT NULL REFERENCES word(id) ON DELETE CASCADE,
+    source_id INTEGER NOT NULL REFERENCES source(id) ON DELETE CASCADE,
+    body TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Raw import lines for replay/QA (optional for early ingest tooling)
+CREATE TABLE lexicon_staging_line (
+    id BIGSERIAL PRIMARY KEY,
+    import_batch_id UUID NOT NULL,
+    file_ref TEXT,
+    line_number INTEGER,
+    raw_line TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_word_display ON word (word);
+CREATE INDEX idx_word_dialect ON word (dialect);
+CREATE INDEX idx_word_source_word_id ON word_source (word_id);
+CREATE INDEX idx_word_source_source_id ON word_source (source_id);
+CREATE INDEX idx_definition_word_id ON definition (word_id);
+CREATE INDEX idx_definition_source_id ON definition (source_id);
+CREATE INDEX idx_definition_word_source ON definition (word_id, source_id);
+CREATE INDEX idx_lexicon_staging_batch ON lexicon_staging_line (import_batch_id);


### PR DESCRIPTION
## What's in here

PR 1 from WORD_CORPUS_PLAN. Swapped the spelling_reference JSONB shape for real tables: `word`, `source`, `word_source`, and `definition`. `lexicon_staging_line` is in the schema for the ingest pipeline we have not wired up yet—intentionally empty for now. Migration `002_lexicon_schema.sql` upgrades databases that already ran the old spelling list; fresh installs pick this up from `schema.sql`. `DictionaryService` plus `build_corpus.py` / `seed_corpus.py` read and write the new layout.

## Worth a closer look

The migration that lifts old `spelling_reference` rows into `word` + `word_source` is the fragile bit—if you have a DB snapshot, spot-check counts and a few known entries after running 002.

## Phase update

Follow-ups: pipe ingest into staging, actually populate staging from sources, then morphological links between surface forms.
