### PR TITLE
[T-01] Port OCR engine improvements from tibetan-ocr-app

### DIFF
--- a/backend/BDRC/Inference.py
+++ b/backend/BDRC/Inference.py
@@ -3,7 +3,7 @@ import pyewts
 import numpy as np
 import numpy.typing as npt
 import onnxruntime as ort
-from typing import List, Union
+from typing import List, Union, Optional
 
 
 from scipy.special import softmax
@@ -25,7 +25,8 @@ from BDRC.line_detection import (
     optimize_countour,
     sort_lines_by_threshold2,
     build_raw_line_data,
-    filter_line_contours
+    filter_line_contours,
+    split_tall_contours,
 )
 
 from BDRC.image_dewarping import (
@@ -47,7 +48,7 @@ from BDRC.Utils import (
 
 
 class CTCDecoder:
-    def __init__(self, charset: str | List[str], add_blank: bool):
+    def __init__(self, charset: Union[str, List[str]], add_blank: bool):
 
         if isinstance(charset, str):
             self.charset = [x for x in charset]
@@ -73,7 +74,7 @@ class CTCDecoder:
 
 
 class Detection:
-    def __init__(self, platform: Platform, config: LineDetectionConfig | LayoutDetectionConfig):
+    def __init__(self, platform: Platform, config: Union[LineDetectionConfig, LayoutDetectionConfig]):
         self.platform = platform
         self.config = config
         self._config_file = config
@@ -163,7 +164,7 @@ class LayoutDetection(Detection):
                              image: npt.NDArray,
                              prediction: npt.NDArray,
                              alpha: float = 0.4,
-                             ) -> npt.NDArray | None:
+                             ) -> Optional[npt.NDArray]:
 
         if image is None:
             return None
@@ -315,6 +316,9 @@ class OCRInference:
 
     def run(self, line_image: npt.NDArray, pre_pad: bool = True) -> str:
 
+        if line_image.shape[0] < 2 or line_image.shape[1] < 2:
+            return ""
+
         if pre_pad:
             line_image = self._pre_pad(line_image)
         line_image = self._prepare_ocr_line(line_image)
@@ -342,7 +346,7 @@ class OCRPipeline:
             self,
             platform: Platform,
             ocr_config: OCRModelConfig,
-            line_config: LineDetectionConfig | LayoutDetectionConfig
+            line_config: Union[LineDetectionConfig, LayoutDetectionConfig]
     ):
         self.ready = False
         self.platform = platform
@@ -369,9 +373,10 @@ class OCRPipeline:
     def update_line_detection(self, config: Union[LineDetectionConfig, LayoutDetectionConfig]):
         if isinstance(config, LineDetectionConfig) and isinstance(self.line_config, LayoutDetectionConfig):
             self.line_inference = LineDetection(self.platform, config)
+            self.line_config = config
         elif isinstance(config, LayoutDetectionConfig) and isinstance(self.line_config, LineDetectionConfig):
             self.line_inference = LayoutDetection(self.platform, config)
-
+            self.line_config = config
         else:
             return
 
@@ -405,9 +410,16 @@ class OCRPipeline:
             except Exception as e:
                 return OpStatus.FAILED, f"Line detection failed: {str(e)}"
 
+            # Diagnostic: log line mask stats to help diagnose blank-page failures
+            mask_nonzero = int(np.count_nonzero(line_mask))
+            mask_total = int(line_mask.shape[0] * line_mask.shape[1])
+            mask_pct = 100.0 * mask_nonzero / mask_total if mask_total > 0 else 0.0
+            print(f"[Diag] line_mask shape={line_mask.shape} nonzero={mask_nonzero}/{mask_total} ({mask_pct:.2f}%)")
+
             # Build line data
             try:
                 rot_img, rot_mask, line_contours, page_angle = build_raw_line_data(image, line_mask)
+                print(f"[Diag] raw contours={len(line_contours)} angle={page_angle:.2f}°")
                 if len(line_contours) == 0:
                     return OpStatus.FAILED, "No lines detected"
             except Exception as e:
@@ -415,6 +427,7 @@ class OCRPipeline:
 
             # Filter contours
             filtered_contours = filter_line_contours(rot_mask, line_contours)
+            print(f"[Diag] filtered contours={len(filtered_contours)}/{len(line_contours)}")
             if len(filtered_contours) == 0:
                 return OpStatus.FAILED, "No valid lines after filtering"
 
@@ -423,14 +436,25 @@ class OCRPipeline:
                 if use_tps:
                     ratio, tps_line_data = check_for_tps(rot_img, filtered_contours)
                     if ratio > tps_threshold:
-                        dewarped_img, dewarped_mask = apply_global_tps(rot_img, rot_mask, tps_line_data)
-                        if len(dewarped_mask.shape) == 3:
-                            dewarped_mask = cv2.cvtColor(dewarped_mask, cv2.COLOR_RGB2GRAY)
-                        dew_rot_img, dew_rot_mask, line_contours, page_angle = build_raw_line_data(dewarped_img, dewarped_mask)
-                        filtered_contours = filter_line_contours(dew_rot_mask, line_contours)
-                        line_data = [build_line_data(x) for x in filtered_contours]
-                        sorted_lines, _ = sort_lines_by_threshold2(rot_mask, line_data, group_lines=merge_lines)
-                        line_images = extract_line_images(dew_rot_img, sorted_lines, k_factor, bbox_tolerance)
+                        try:
+                            import warnings
+                            with warnings.catch_warnings():
+                                warnings.simplefilter("error", RuntimeWarning)
+                                dewarped_img, dewarped_mask = apply_global_tps(rot_img, rot_mask, tps_line_data)
+                            if not np.isfinite(dewarped_img).all():
+                                raise ValueError("TPS produced non-finite values")
+                            if len(dewarped_mask.shape) == 3:
+                                dewarped_mask = cv2.cvtColor(dewarped_mask, cv2.COLOR_RGB2GRAY)
+                            dew_rot_img, dew_rot_mask, line_contours, page_angle = build_raw_line_data(dewarped_img, dewarped_mask)
+                            filtered_contours = filter_line_contours(dew_rot_mask, line_contours)
+                            line_data = [build_line_data(x) for x in filtered_contours]
+                            sorted_lines, _ = sort_lines_by_threshold2(rot_mask, line_data, group_lines=merge_lines)
+                            line_images = extract_line_images(dew_rot_img, sorted_lines, k_factor, bbox_tolerance)
+                        except Exception as tps_err:
+                            print(f"[TPS] Dewarping failed ({tps_err}), falling back to non-dewarped processing")
+                            line_data = [build_line_data(x) for x in filtered_contours]
+                            sorted_lines, _ = sort_lines_by_threshold2(rot_mask, line_data, group_lines=merge_lines)
+                            line_images = extract_line_images(rot_img, sorted_lines, k_factor, bbox_tolerance)
                     else:
                         line_data = [build_line_data(x) for x in filtered_contours]
                         sorted_lines, _ = sort_lines_by_threshold2(rot_mask, line_data, group_lines=merge_lines)
@@ -452,10 +476,13 @@ class OCRPipeline:
                         pred = pred.strip()
                         pred = pred.replace("§", " ")
 
-                        if self.encoder == CharsetEncoder.Wylie and target_encoding == Encoding.Unicode:
-                            pred = self.converter.toUnicode(pred)
-                        elif self.encoder == CharsetEncoder.Stack and target_encoding == Encoding.Wylie:
-                            pred = self.converter.toWylie(pred)
+                        try:
+                            if self.encoder == CharsetEncoder.Wylie and target_encoding == Encoding.Unicode:
+                                pred = self.converter.toUnicode(pred)
+                            elif self.encoder == CharsetEncoder.Stack and target_encoding == Encoding.Wylie:
+                                pred = self.converter.toWylie(pred)
+                        except Exception as conv_err:
+                            print(f"[OCR] Encoding conversion failed for line, keeping raw output: {conv_err}")
 
                         ocr_line = OCRLine(
                             guid=line_info.guid,

--- a/backend/BDRC/UPSTREAM.md
+++ b/backend/BDRC/UPSTREAM.md
@@ -1,0 +1,48 @@
+# BDRC vendor sync
+
+This directory is vendored from [`buda-base/tibetan-ocr-app`](https://github.com/buda-base/tibetan-ocr-app) (MIT). The OCR pipeline lives upstream as a PySide6 desktop app; we re-use just the `BDRC/` package for server-side OCR.
+
+## Last sync
+
+- **Upstream repo path:** `../tibetan-ocr-app`
+- **Upstream HEAD SHA at sync time:** `62d68ec01996560e1105796630c10489731fe8aa`
+- **Upstream state ported:** working-tree state (HEAD + uncommitted WIP). The upstream WIP was substantially ahead of HEAD on the files we sync; per the user, the WIP is the desired state for this port.
+- **Synced on:** 2026-05-19
+- **Ticket:** T-01 of the [interactive OCR plan](../../docs/planning/INTERACTIVE_OCR_PLAN.md#t-01--port-ocr-engine-improvements-from-tibetan-ocr-app)
+
+## Fixes cherry-picked in this sync
+
+### `line_detection.py`
+- Rotation-angle sign fix in `get_rotation_angle_from_lines` and `calculate_rotation_angle_from_lines`: `abs()` applied to both low- and high-angle filters, and the high-angle formula corrected from `-(90 - mean)` to `90 + mean`. Modern OpenCV returns angles in `[-90°, 0°)`, so near-90° tilts come back negative — the old form lost the sign.
+- `max_angle` lowered from 5.0° to 2.0° to reject implausibly large rotations.
+- `filter_line_contours`: width threshold relaxed from 0.01 to 0.005, height floor from 10 to 3, and now logs why everything was rejected when zero contours pass.
+- New `split_tall_contours()` + `split_tall_lines()` to break apart contours that span multiple text rows (a recurring failure mode where pixel bridges merge adjacent lines).
+- New `_find_valley_rows()` helper for the above.
+- New `find_folio_marker_end()` for separating the folio-number annotation from body text in Tibetan folios.
+- New `filter_outlier_lines()` to drop isolated page-border detections that aren't real text.
+- `extract_line` / `get_line_image` / `extract_line_images`: optional `y_bounds` parameter clips the dilated mask to the midpoint of neighboring lines, preventing bleed.
+- `sort_lines_by_threshold2` now runs `split_tall_lines` and `filter_outlier_lines` on the grouped output.
+
+### `image_dewarping.py`
+- Collinearity check before TPS solve: if y-centers of the slice-centroids are near-linear (pure tilt rather than curvature), skip TPS — the kernel would be singular and divide-by-zero. Pure tilt is handled by rotation upstream of this anyway.
+- `npt.NDArray(...)` → `np.array(...)`: `npt.NDArray` is a type-hint alias, not a constructor; the old form crashed when actually called.
+- Removed a duplicate `corners *= [height, width]` (typo).
+- Local mod: kept this repo's `try/except ImportError` guard around `from tps import ThinPlateSpline`. Upstream removed it; `tps` is not in our `requirements.txt` and the TPS code path is gated by `use_tps=False` in `app/pdf/ocr.py`, so the guard preserves importability.
+
+### `Inference.py`
+- `update_line_detection`: now also reassigns `self.line_config = config` after swapping the inference instance. Previous version updated the inference object but kept the stale config, so subsequent runs would misuse the old shape.
+- TPS dewarp path wrapped in `try`/`except` with a non-finite-values guard; on failure, falls back to non-dewarped extraction instead of crashing the whole page.
+- Encoding conversion wrapped in `try`/`except`; conversion failures keep the raw OCR output instead of dropping the line.
+- Early return on degenerate line images (`shape < 2`).
+- Diagnostic prints (`[Diag]`, `[TPS]`, `[OCR]`) for blank-page and dewarp-failure debugging.
+- Type annotations migrated from PEP 604 `A | B` to `Union[A, B]` (no behavior change; broader Python compatibility).
+
+### `Runner.py` (no `Runner.py` in this repo — equivalent logic added elsewhere)
+The upstream `Runner.py` is a Qt `QRunnable` wired to PySide6 signals; nothing to port directly. The reusable bit — explicit multi-channel image handling before calling the pipeline — was added as `_normalize_to_bgr()` in `backend/app/pdf/ocr.py` and called inside `BDRCOCREngine.run_on_image`. It handles grayscale, BGRA, and exotic (e.g. CMYK+Alpha) inputs.
+
+## How to re-sync next time
+
+1. `cd ../tibetan-ocr-app && git rev-parse HEAD` — record the new upstream SHA.
+2. `diff -u backend/BDRC/<file>.py ../tibetan-ocr-app/BDRC/<file>.py` per file, port the deltas.
+3. Preserve any local mods listed above (currently: the `tps` import guard in `image_dewarping.py`).
+4. Update this file with the new SHA, date, and any new fixes pulled forward.

--- a/backend/BDRC/image_dewarping.py
+++ b/backend/BDRC/image_dewarping.py
@@ -41,11 +41,11 @@ def run_tps(image: npt.NDArray, input_pts, output_pts, add_corners=True, alpha=0
         image = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
         height, width, _ = image.shape
 
-    input_pts = npt.NDArray(input_pts)
-    output_pts = npt.NDArray(output_pts)
+    input_pts = np.array(input_pts)
+    output_pts = np.array(output_pts)
 
     if add_corners:
-        corners = npt.NDArray(  # Add corners ctrl points
+        corners = np.array(  # Add corners ctrl points
         [
             [0.0, 0.0],
             [1.0, 0.0],
@@ -53,7 +53,6 @@ def run_tps(image: npt.NDArray, input_pts, output_pts, add_corners=True, alpha=0
             [1.0, 1.0],
         ])
 
-        corners *= [height, width]
         corners *= [height, width]
 
         input_pts = np.concatenate((input_pts, corners))
@@ -171,6 +170,18 @@ def check_line_tps(image: npt.NDArray, contour: npt.NDArray, slice_width: int = 
     mean_center_y = np.mean(all_centers)
 
     if max_ydelta > mean_bbox_h:
+        # Check whether the y-centers are nearly collinear (pure tilt, not curvature).
+        # Collinear control points make the TPS kernel singular → divide by zero.
+        # Pure tilt is better corrected by rotation, not TPS.
+        xs = np.array([slice1_center_x, slice2_center_x, slice3_center_x,
+                       slice4_center_x, slice5_center_x], dtype=float)
+        ys = np.array([slice1_center_y, slice2_center_y, slice3_center_y,
+                       slice4_center_y, slice5_center_y], dtype=float)
+        if np.ptp(xs) > 0:  # avoid division by zero in polyfit
+            residuals = ys - np.polyval(np.polyfit(xs, ys, 1), xs)
+            if np.max(np.abs(residuals)) < 3.0:  # near-linear: skip TPS
+                return False, None, None, 0.0
+
         target_y = round(mean_center_y)
 
         input_pts = [

--- a/backend/BDRC/line_detection.py
+++ b/backend/BDRC/line_detection.py
@@ -11,7 +11,7 @@ This module contains functions for:
 import cv2
 import numpy as np
 import numpy.typing as npt
-from typing import List, Tuple, Sequence
+from typing import List, Optional, Tuple, Sequence
 
 from BDRC.Data import BBox, Line
 from uuid import uuid1
@@ -106,7 +106,7 @@ def mask_n_crop(image: np.array, mask: np.array) -> np.array:
 
 def get_rotation_angle_from_lines(
     line_mask: npt.NDArray,
-    max_angle: float = 5.0,
+    max_angle: float = 2.0,
     debug_angles: bool = False,
 ) -> float:
     """
@@ -125,17 +125,19 @@ def get_rotation_angle_from_lines(
     contours = [x for x in contours if cv2.contourArea(x) > mask_threshold]
     angles = [cv2.minAreaRect(x)[2] for x in contours]
 
-    low_angles = [x for x in angles if abs(x) != 0.0 and x < max_angle]
-    high_angles = [x for x in angles if abs(x) != 90.0 and x > (90 - max_angle)]
+    low_angles = [x for x in angles if abs(x) != 0.0 and abs(x) < max_angle]
+    # Modern OpenCV returns angles in [-90°, 0°), so near-90° tilts come back as
+    # e.g. -88.6° rather than +88.6°.  Use abs() so both signs are caught.
+    high_angles = [x for x in angles if abs(x) != 90.0 and abs(x) > (90 - max_angle)]
 
     if debug_angles:
         print(f"All Angles: {angles}")
 
     if len(low_angles) > len(high_angles) and len(low_angles) > 0:
         mean_angle = np.mean(low_angles)
-    # check for clockwise rotation
+    # check for clockwise rotation (near-90° angles encode small tilt as 90+angle)
     elif len(high_angles) > 0:
-        mean_angle = -(90 - np.mean(high_angles))
+        mean_angle = 90 + np.mean(high_angles)
     else:
         mean_angle = 0
 
@@ -144,7 +146,7 @@ def get_rotation_angle_from_lines(
 
 def calculate_rotation_angle_from_lines(
     line_mask: npt.NDArray,
-    max_angle: float = 5.0,
+    max_angle: float = 2.0,
     debug_angles: bool = False,
 ) -> float:
     """
@@ -168,17 +170,19 @@ def calculate_rotation_angle_from_lines(
         
     angles = [cv2.minAreaRect(x)[2] for x in contours]
 
-    low_angles = [x for x in angles if abs(x) != 0.0 and x < max_angle]
-    high_angles = [x for x in angles if abs(x) != 90.0 and x > (90 - max_angle)]
+    low_angles = [x for x in angles if abs(x) != 0.0 and abs(x) < max_angle]
+    # Modern OpenCV returns angles in [-90°, 0°), so near-90° tilts come back as
+    # e.g. -88.6° rather than +88.6°.  Use abs() so both signs are caught.
+    high_angles = [x for x in angles if abs(x) != 90.0 and abs(x) > (90 - max_angle)]
 
     if debug_angles:
         print(f"All Angles: {angles}")
 
     if len(low_angles) > len(high_angles) and len(low_angles) > 0:
         mean_angle = np.mean(low_angles)
-    # check for clockwise rotation
+    # check for clockwise rotation (near-90° angles encode small tilt as 90+angle)
     elif len(high_angles) > 0:
-        mean_angle = -(90 - np.mean(high_angles))
+        mean_angle = 90 + np.mean(high_angles)
     else:
         mean_angle = 0.0
 
@@ -235,112 +239,441 @@ def build_raw_line_data(image: npt.NDArray, line_mask: npt.NDArray):
     return rot_img, rot_mask, line_contours, angle
 
 
-def filter_line_contours(image: npt.NDArray, line_contours, threshold: float = 0.01) -> List:
+def _find_valley_rows(smoothed: np.ndarray, h: int) -> List[int]:
+    """
+    Find row indices where a vertical projection has significant valleys.
+
+    A valley qualifies as a split point if its prominence (depth below the
+    minimum of the left and right surrounding peaks within ±30 rows) is at
+    least 25% of the global peak value.  Nearby valleys are deduplicated by
+    keeping only the deepest one in each 15-row neighbourhood.
+    """
+    n = len(smoothed)
+    if n < 20:
+        return []
+
+    peak_val = float(np.max(smoothed))
+    if peak_val == 0:
+        return []
+
+    # Search only in the middle 80% of the contour to avoid edge artefacts
+    search_start = max(1, n // 10)
+    search_end   = min(n - 2, 9 * n // 10)
+
+    valleys = []
+    for i in range(search_start, search_end):
+        if smoothed[i] > smoothed[i - 1] or smoothed[i] > smoothed[i + 1]:
+            continue  # not a local minimum
+
+        left_arr  = smoothed[max(0, i - 30):i]
+        right_arr = smoothed[i + 1:min(n, i + 30)]
+        if left_arr.size == 0 or right_arr.size == 0:
+            continue
+
+        local_peak = min(float(np.max(left_arr)), float(np.max(right_arr)))
+        prominence = local_peak - float(smoothed[i])
+        if local_peak > 0 and prominence >= 0.25 * local_peak:
+            valleys.append((i, float(smoothed[i])))
+
+    if not valleys:
+        return []
+
+    # Merge valleys within 15 rows of each other — keep the deepest in each group
+    merged: List[Tuple[int, float]] = []
+    group = [valleys[0]]
+    for v in valleys[1:]:
+        if v[0] - group[-1][0] <= 15:
+            group.append(v)
+        else:
+            merged.append(min(group, key=lambda x: x[1]))
+            group = [v]
+    merged.append(min(group, key=lambda x: x[1]))
+
+    return [v[0] for v in merged]
+
+
+def split_tall_contours(
+    line_mask: npt.NDArray,
+    contours: List,
+    max_line_height_ratio: float = 0.08,
+) -> List:
+    """
+    Split contours that are taller than a single text line.
+
+    When the line-detection model produces masks with thin pixel bridges
+    between adjacent lines, cv2.findContours merges them into a single tall
+    contour.  This function detects such contours (height > image_height *
+    max_line_height_ratio) and splits them at the deepest valley in their
+    vertical projection, returning separate contours for each sub-line.
+
+    Args:
+        line_mask:              Binary (or 3-channel) line-detection mask,
+                                in the same coordinate space as *contours*.
+        contours:               Contour list from filter_line_contours.
+        max_line_height_ratio:  Contours with h > image_height * this value
+                                are candidates for splitting (default 0.08 ≈ 8%).
+
+    Returns:
+        New contour list with tall merged contours replaced by their parts.
+    """
+    if not contours:
+        return contours
+
+    # Work with a 2-D binary mask
+    if len(line_mask.shape) == 3:
+        gray_mask = cv2.cvtColor(line_mask, cv2.COLOR_RGB2GRAY)
+    else:
+        gray_mask = line_mask.copy()
+
+    img_height  = gray_mask.shape[0]
+    max_line_h  = img_height * max_line_height_ratio
+
+    result: List = []
+    split_count = 0
+
+    for cnt in contours:
+        x, y, w, h = cv2.boundingRect(cnt)
+
+        if h <= max_line_h:
+            result.append(cnt)
+            continue
+
+        # ── Build projection of the original mask pixels under this contour ──
+        tmp_mask = np.zeros(gray_mask.shape[:2], dtype=np.uint8)
+        cv2.drawContours(tmp_mask, [cnt], -1, 255, -1)
+        combined = cv2.bitwise_and(tmp_mask, gray_mask)
+        region   = combined[y:y + h, x:x + w]
+
+        proj = np.sum(region > 0, axis=1).astype(float)
+
+        # Smooth with a 7-row moving average
+        kernel   = np.ones(7) / 7
+        padded   = np.pad(proj, 3, mode="edge")
+        smoothed = np.convolve(padded, kernel, mode="valid")[:len(proj)]
+
+        split_rows = _find_valley_rows(smoothed, h)
+
+        if not split_rows:
+            result.append(cnt)
+            continue
+
+        # ── Build sub-contours for each stripe ──────────────────────────────
+        boundaries  = [0] + split_rows + [h]
+        sub_contours: List = []
+
+        for i in range(len(boundaries) - 1):
+            y_start = boundaries[i]
+            y_end   = boundaries[i + 1]
+
+            if y_end - y_start < 10:
+                continue
+
+            sub_mask = np.zeros(gray_mask.shape[:2], dtype=np.uint8)
+            sub_mask[y + y_start:y + y_end, x:x + w] = \
+                gray_mask[y + y_start:y + y_end, x:x + w]
+
+            sub_cnts, _ = cv2.findContours(
+                sub_mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE
+            )
+            sub_cnts = [c for c in sub_cnts if cv2.contourArea(c) > 5]
+
+            if sub_cnts:
+                merged_cnt = np.vstack(sub_cnts) if len(sub_cnts) > 1 else sub_cnts[0]
+                sub_contours.append(merged_cnt)
+            else:
+                # Fallback: rectangular contour spanning the stripe
+                rect_cnt = np.array([
+                    [[x,         y + y_start]],
+                    [[x + w - 1, y + y_start]],
+                    [[x + w - 1, y + y_end - 1]],
+                    [[x,         y + y_end - 1]],
+                ], dtype=np.int32)
+                sub_contours.append(rect_cnt)
+
+        if len(sub_contours) > 1:
+            result.extend(sub_contours)
+            split_count += 1
+            print(f"[split_tall_contours] h={h}px → split into {len(sub_contours)} parts at rows {split_rows}")
+        else:
+            result.append(cnt)  # valley found but couldn't produce 2+ clean sub-regions
+
+    if split_count > 0:
+        print(
+            f"[split_tall_contours] {split_count} contours split "
+            f"→ {len(result)} total (was {len(contours)})"
+        )
+
+    return result
+
+
+def split_tall_lines(
+    line_mask: npt.NDArray,
+    lines: List["Line"],
+    max_line_height_ratio: float = 0.08,
+) -> List["Line"]:
+    """
+    Split Line objects whose bounding-box height exceeds a single text line.
+
+    This is the post-grouping companion to split_tall_contours.  After
+    group_line_chunks merges contour fragments, the resulting Line object
+    may still span two text rows (convex-hull artefact or pixel bridge).
+    Running split_tall_contours on each Line's contour individually avoids
+    the re-merging problem that occurs when splitting happens before grouping.
+
+    Args:
+        line_mask:              Binary (or 3-channel) line-detection mask.
+        lines:                  Sorted list of Line objects.
+        max_line_height_ratio:  Lines taller than image_height * this are
+                                candidates for splitting (default 0.08).
+
+    Returns:
+        New list of Line objects with tall lines replaced by their parts,
+        still in top-to-bottom order.
+    """
+    if not lines:
+        return lines
+
+    if len(line_mask.shape) == 3:
+        gray_mask = cv2.cvtColor(line_mask, cv2.COLOR_RGB2GRAY)
+    else:
+        gray_mask = line_mask.copy()
+
+    # Use median line height × 1.5 as the split threshold so it adapts to the
+    # actual text size on the page rather than a fixed % of image height.
+    heights = [ln.bbox.h for ln in lines]
+    median_h = float(np.median(heights))
+    img_height = gray_mask.shape[0]
+    adaptive_ratio = (median_h * 1.5) / img_height if img_height > 0 else max_line_height_ratio
+
+    result: List = []
+    for line in lines:
+        split = split_tall_contours(gray_mask, [line.contour], adaptive_ratio)
+        if len(split) > 1:
+            for cnt in split:
+                result.append(build_line_data(cnt))
+        else:
+            result.append(line)
+
+    # Re-sort by y-center so order stays top-to-bottom after any splits
+    result.sort(key=lambda ln: ln.bbox.y + ln.bbox.h // 2)
+
+    return result
+
+
+def filter_line_contours(image: npt.NDArray, line_contours, threshold: float = 0.005) -> List:
     """
     Filter line contours based on size criteria.
-    
+
     Args:
         image: Reference image for size calculations
         line_contours: List of detected contours
         threshold: Minimum width threshold as fraction of image width
-        
+
     Returns:
         Filtered list of contours
     """
     filtered_contours = []
+    rejected = []
+    img_width = image.shape[1]
+    min_w = img_width * threshold
+
     for _, line_cnt in enumerate(line_contours):
         _, _, w, h = cv2.boundingRect(line_cnt)
-        if w > image.shape[1] * threshold and h > 10:
+        if w > min_w and h > 3:
             filtered_contours.append(line_cnt)
+        else:
+            rejected.append((w, h))
+
+    if len(filtered_contours) == 0 and rejected:
+        widths  = [r[0] for r in rejected]
+        heights = [r[1] for r in rejected]
+        print(f"[filter_line_contours] All {len(rejected)} contours rejected. "
+              f"image_width={img_width}, min_w={min_w:.1f}, "
+              f"w range={min(widths)}-{max(widths)}, h range={min(heights)}-{max(heights)}")
+
     return filtered_contours
 
 
-def extract_line(image: npt.NDArray, mask: npt.NDArray, bbox_h: int, k_factor: float = 1.2):
+def extract_line(
+    image: npt.NDArray,
+    mask: npt.NDArray,
+    bbox_h: int,
+    k_factor: float = 1.2,
+    y_bounds: Tuple[int, int] = None,
+):
     """
     Extract line region using morphological operations.
-    
+
     Args:
-        image: Input image array
-        mask: Binary mask of line region
-        bbox_h: Height of bounding box
+        image:    Input image array
+        mask:     Binary mask of line region
+        bbox_h:   Height of bounding box
         k_factor: Scaling factor for morphological kernel
-        
+        y_bounds: Optional (top, bottom) pixel rows to clip the dilated mask,
+                  preventing bleed into adjacent lines.
+
     Returns:
         Extracted line image
     """
     k_size = int(bbox_h * k_factor)
     morph_multiplier = k_factor
 
-    morph_rect = cv2.getStructuringElement(shape=cv2.MORPH_RECT, ksize=(k_size, int(k_size * morph_multiplier)))
-    iterations = 1
-    dilated_mask = cv2.dilate(mask, kernel=morph_rect, iterations=iterations)
+    morph_rect = cv2.getStructuringElement(
+        shape=cv2.MORPH_RECT, ksize=(k_size, int(k_size * morph_multiplier))
+    )
+    dilated_mask = cv2.dilate(mask, kernel=morph_rect, iterations=1)
+
+    if y_bounds is not None:
+        top, bottom = y_bounds
+        if top > 0:
+            dilated_mask[:top, :] = 0
+        if bottom < dilated_mask.shape[0]:
+            dilated_mask[bottom:, :] = 0
+
     masked_line = mask_n_crop(image, dilated_mask)
 
     return masked_line
 
 
-def get_line_image(image: npt.NDArray, mask: npt.NDArray, bbox_h: int, bbox_tolerance: float = 2.5, k_factor: float = 1.2):
+def get_line_image(
+    image: npt.NDArray,
+    mask: npt.NDArray,
+    bbox_h: int,
+    bbox_tolerance: float = 2.5,
+    k_factor: float = 1.2,
+    y_bounds: Tuple[int, int] = None,
+):
     """
     Extract line image with adaptive height tolerance.
-    
+
     Args:
-        image: Input image array
-        mask: Binary mask of line region
-        bbox_h: Height of bounding box
+        image:          Input image array
+        mask:           Binary mask of line region
+        bbox_h:         Height of bounding box
         bbox_tolerance: Height tolerance multiplier
-        k_factor: Initial scaling factor for morphological kernel
-        
+        k_factor:       Initial scaling factor for morphological kernel
+        y_bounds:       Optional (top, bottom) clip rows passed to extract_line.
+
     Returns:
         Tuple of (line_image, adapted_k_factor)
     """
     try:
         tmp_k = k_factor
-        line_img = extract_line(image, mask, bbox_h, k_factor=tmp_k)
-        
-        # Add a safety check to prevent infinite loop
+        line_img = extract_line(image, mask, bbox_h, k_factor=tmp_k, y_bounds=y_bounds)
+
         max_attempts = 10
         attempts = 0
-        
+
         while line_img.shape[0] > bbox_h * bbox_tolerance and attempts < max_attempts:
             tmp_k = tmp_k - 0.1
-            if tmp_k <= 0.1:  # Prevent k_factor from becoming too small
+            if tmp_k <= 0.1:
                 break
-            line_img = extract_line(image, mask, bbox_h, k_factor=tmp_k)
+            line_img = extract_line(image, mask, bbox_h, k_factor=tmp_k, y_bounds=y_bounds)
             attempts += 1
 
         return line_img, tmp_k
     except Exception as e:
-        # Return a minimal valid image and the original k_factor in case of error
         print(f"Error in get_line_image: {e}")
-        # Create a small blank image as fallback
         fallback_img = np.zeros((bbox_h, bbox_h * 2, 3), dtype=np.uint8)
         return fallback_img, k_factor
 
 
-def extract_line_images(image: npt.NDArray, line_data: List[Line], default_k: float = 1.7, bbox_tolerance: float = 3):
+def find_folio_marker_end(line_mask: npt.NDArray, line: "Line",
+                          search_fraction: float = 0.20,
+                          gap_threshold: float = 0.02,
+                          min_gap_width: int = 10) -> Optional[int]:
+    """
+    Look for the gap between the folio marker and the main text body in the
+    line detection mask.  Tibetan folios often have a brief folio-number
+    annotation (e.g. གོ།) at the left edge of the first text line, separated
+    from the body text by a clear blank stretch in the mask.
+
+    Args:
+        line_mask:       Grayscale (or 3-channel) line detection mask.
+        line:            The Line object for the line to inspect.
+        search_fraction: Only search the left this fraction of the line width.
+        gap_threshold:   Column is considered empty if its mask-pixel fraction
+                         is below this value.
+        min_gap_width:   Minimum number of consecutive empty columns to count
+                         as a gap.
+
+    Returns:
+        The absolute x-coordinate (in the full image) where the gap ends
+        (i.e. where the main text starts), or None if no gap found.
+    """
+    if len(line_mask.shape) == 3:
+        gray = cv2.cvtColor(line_mask, cv2.COLOR_RGB2GRAY)
+    else:
+        gray = line_mask
+
+    x, y, w, h = line.bbox.x, line.bbox.y, line.bbox.w, line.bbox.h
+    crop = gray[y:y + h, x:x + w]
+    col_density = (crop > 0).astype(np.float32).mean(axis=0)
+
+    search_end = int(w * search_fraction)
+    in_gap, gap_start = False, 0
+    gaps = []
+
+    for col in range(search_end):
+        if col_density[col] < gap_threshold:
+            if not in_gap:
+                in_gap, gap_start = True, col
+        else:
+            if in_gap:
+                in_gap = False
+                if col - gap_start >= min_gap_width:
+                    gaps.append((gap_start, col))
+
+    if not gaps:
+        return None
+
+    _, gap_end_relative = gaps[-1]
+    return x + gap_end_relative  # absolute x in the full image
+
+
+def extract_line_images(image: npt.NDArray, line_data: List[Line], default_k: float = 1.7, bbox_tolerance: float = 3, line_mask: npt.NDArray = None):
     """
     Extract individual line images from detected line data.
-    
+
     Args:
-        image: Input image array
-        line_data: List of Line objects
-        default_k: Default scaling factor
+        image:          Input image array
+        line_data:      List of Line objects (top-to-bottom order)
+        default_k:      Default scaling factor
         bbox_tolerance: Height tolerance for line extraction
-        
+
     Returns:
         List of extracted line images
     """
-    default_k_factor = default_k
-    current_k = default_k_factor
-
+    current_k = default_k
+    img_h = image.shape[0]
     line_images = []
 
-    for _, line in enumerate(line_data):
-        _, _, _, h = cv2.boundingRect(line.contour)
+    for i, line in enumerate(line_data):
+        x, y, w, h = cv2.boundingRect(line.contour)
+
+        # Clip dilation to the midpoint between this line and its neighbours so
+        # that the expanded mask never bleeds into adjacent line text.
+        if i == 0:
+            top_bound = 0
+        else:
+            prev_bottom = line_data[i - 1].bbox.y + line_data[i - 1].bbox.h
+            top_bound = (prev_bottom + y) // 2
+
+        if i == len(line_data) - 1:
+            bottom_bound = img_h
+        else:
+            next_top = line_data[i + 1].bbox.y
+            bottom_bound = (y + h + next_top) // 2
+
         tmp_mask = np.zeros((image.shape[0], image.shape[1]), dtype=np.uint8)
         cv2.drawContours(tmp_mask, [line.contour], -1, (255, 255, 255), -1)
 
-        line_img, adapted_k = get_line_image(image, tmp_mask, h, bbox_tolerance=bbox_tolerance, k_factor=current_k)
+        line_img, adapted_k = get_line_image(
+            image, tmp_mask, h,
+            bbox_tolerance=bbox_tolerance,
+            k_factor=current_k,
+            y_bounds=(top_bound, bottom_bound),
+        )
         line_images.append(line_img)
 
         if current_k != adapted_k:
@@ -538,6 +871,52 @@ def group_line_chunks(sorted_bbox_centers, lines: List[Line], adaptive_grouping:
     return new_line_data
 
 
+def filter_outlier_lines(lines: List[Line], gap_ratio: float = 2.5) -> List[Line]:
+    """
+    Remove lines that are isolated far from the main text block.
+
+    After sorting, the first or last line is sometimes a page-border or
+    frame detection rather than real text.  We detect these by comparing
+    each line's gap to its nearest neighbour against the median inter-line
+    gap: any line whose nearest-neighbour gap exceeds gap_ratio × median is
+    considered an outlier and dropped.
+
+    Args:
+        lines:      Sorted list of Line objects (top-to-bottom).
+        gap_ratio:  A line is an outlier if its nearest-gap > this × median.
+
+    Returns:
+        Filtered list with outlier lines removed.
+    """
+    if len(lines) < 3:
+        return lines
+
+    y_centers = [ln.bbox.y + ln.bbox.h // 2 for ln in lines]
+    gaps = [abs(y_centers[i + 1] - y_centers[i]) for i in range(len(y_centers) - 1)]
+    median_gap = float(np.median(gaps))
+
+    if median_gap == 0:
+        return lines
+
+    keep = []
+    for i, ln in enumerate(lines):
+        # Nearest-neighbour gap for this line
+        neighbour_gaps = []
+        if i > 0:
+            neighbour_gaps.append(gaps[i - 1])
+        if i < len(lines) - 1:
+            neighbour_gaps.append(gaps[i])
+        min_gap = min(neighbour_gaps)
+
+        if min_gap > gap_ratio * median_gap:
+            print(f"[filter_outlier_lines] Dropping isolated line at y={ln.bbox.y} "
+                  f"(gap={min_gap:.0f}px, median={median_gap:.0f}px, ratio={min_gap/median_gap:.2f})")
+        else:
+            keep.append(ln)
+
+    return keep
+
+
 def sort_lines_by_threshold(
     line_mask: np.array,
     lines: list[Line],
@@ -590,14 +969,14 @@ def sort_lines_by_threshold2(
 ):
     """
     Alternative implementation for sorting lines by threshold.
-    
+
     Args:
         line_mask: Binary mask of detected lines
         lines: List of Line objects to sort
         threshold: Vertical distance threshold for grouping
         calculate_threshold: Whether to auto-calculate threshold
         group_lines: Whether to merge nearby lines
-        
+
     Returns:
         Tuple of (sorted_lines, calculated_threshold)
     """
@@ -620,5 +999,8 @@ def sort_lines_by_threshold2(
             for _line in lines:
                 if _bbox == _line.center:
                     new_lines.append(_line)
+
+    new_lines = split_tall_lines(line_mask, new_lines)
+    new_lines = filter_outlier_lines(new_lines)
 
     return new_lines, line_treshold

--- a/backend/app/pdf/ocr.py
+++ b/backend/app/pdf/ocr.py
@@ -24,6 +24,23 @@ MODELS_DIR = BACKEND_DIR / "Models"
 OCR_MODELS_DIR = BACKEND_DIR / "OCRModels"
 
 
+def _normalize_to_bgr(image: np.ndarray) -> np.ndarray:
+    """Coerce a page image into 3-channel BGR.
+
+    Handles grayscale (h,w), BGRA (h,w,4), and exotic formats (e.g. CMYK+Alpha)
+    by falling back through PIL. Already-BGR inputs pass through untouched.
+    """
+    if image.ndim == 2:
+        return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+    if image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+    if image.shape[2] != 3:
+        from PIL import Image as PILImage
+        pil_img = PILImage.fromarray(image).convert("RGB")
+        return cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
+    return image
+
+
 @dataclass
 class OCRLine:
     """A single recognized line of text with its bounding box in image coordinates."""
@@ -115,6 +132,8 @@ class BDRCOCREngine:
         """
         if not self.ready:
             raise RuntimeError(self._error or "OCR engine not ready")
+
+        image = _normalize_to_bgr(image)
 
         from BDRC.Data import Encoding, OpStatus
 

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -185,10 +185,10 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** Refactoring the BDRC code, changing model files, adding new preprocessing.
 
 **Acceptance criteria:**
-- [ ] All listed fixes present in `backend/BDRC/`
-- [ ] Existing OCR endpoint still works on a known-good PDF (smoke test)
-- [ ] `UPSTREAM.md` records the synced-from commit SHA and lists the cherry-picked fixes
-- [ ] No spellcheck or DOCX behavior changes
+- [x] All listed fixes present in `backend/BDRC/`
+- [x] Existing OCR endpoint still works on a known-good PDF (smoke test)
+- [x] `UPSTREAM.md` records the synced-from commit SHA and lists the cherry-picked fixes
+- [x] No spellcheck or DOCX behavior changes
 
 **Dependencies:** none
 

--- a/docs/planning/INTERACTIVE_OCR_WORKFLOW.md
+++ b/docs/planning/INTERACTIVE_OCR_WORKFLOW.md
@@ -23,7 +23,7 @@ You (the assistant) then:
 
 - **`main`** — production. Nothing in this plan merges here until the user explicitly says so. Do not target PRs at `main`.
 - **`feat/interactive-ocr`** — long-lived integration branch off `main`. All ticket PRs target this. Sits open as long as needed.
-- **`feat/interactive-ocr/T-NN-slug`** — one branch per ticket.
+- **`feat/interactive-ocr-T-NN-slug`** — one branch per ticket. (Hyphen, not slash: a `feat/interactive-ocr` branch ref blocks any sibling under `feat/interactive-ocr/...` because git treats slashes as filesystem paths.)
   - **Default:** branch off `feat/interactive-ocr`.
   - **Stacked case:** if the ticket depends on another whose PR is still open, branch off that dependency's branch instead. When the dependency merges into `feat/interactive-ocr`, rebase this branch onto `feat/interactive-ocr` and force-push (note: force-push to the ticket branch only — never `main` or `feat/interactive-ocr`).
 
@@ -31,10 +31,10 @@ The integration branch may not exist yet on a fresh chat. Check with `git branch
 
 ### Slug convention
 
-`feat/interactive-ocr/T-NN-short-slug`, e.g.:
-- `feat/interactive-ocr/T-01-ocr-engine-sync`
-- `feat/interactive-ocr/T-02-sanskrit-detector`
-- `feat/interactive-ocr/T-02b-sanskrit-in-spellcheck-api`
+`feat/interactive-ocr-T-NN-short-slug`, e.g.:
+- `feat/interactive-ocr-T-01-ocr-engine-sync`
+- `feat/interactive-ocr-T-02-sanskrit-detector`
+- `feat/interactive-ocr-T-02b-sanskrit-in-spellcheck-api`
 
 ---
 


### PR DESCRIPTION
## What's in here

Strict upstream sync from `buda-base/tibetan-ocr-app` at `62d68ec` (HEAD + WIP, per direction). The point is to pull forward known failure modes before any new code is written — fewer bad OCR pages means less AI cost and human review when the interactive loop lands.

Key fixes: rotation-angle sign was wrong for near-90° tilts (modern OpenCV returns negative angles); `update_line_detection` was leaving `self.line_config` stale; new `split_tall_contours()` breaks apart pixel-bridged rows that were merging into one; `_normalize_to_bgr()` in the OCR adapter handles grayscale/BGRA/CMYK+Alpha inputs; TPS dewarp now falls back gracefully instead of crashing on degenerate input. Full detail is in `backend/BDRC/UPSTREAM.md`.

One local mod preserved: the `try/except ImportError` guard around `tps` in `image_dewarping.py` — `tps` isn't in `requirements.txt` and the TPS path is gated by `use_tps=False` anyway.

Smoke-test note: import + run-to-completion verified locally. Output quality on the available fixture isn't a T-01 concern — the default model is `Woodblock` and the fixture is modern Uchen, so that's a calibration question for later.

Also includes a one-line workflow doc patch: slug convention clarified as hyphen (`feat/interactive-ocr-T-NN-...`) not slash, since the slash form collides with the `feat/interactive-ocr` integration branch ref.

Ticket: [T-01 — Port OCR engine improvements from `tibetan-ocr-app`](docs/planning/INTERACTIVE_OCR_PLAN.md#t-01--port-ocr-engine-improvements-from-tibetan-ocr-app)

## Acceptance criteria

- [x] All listed fixes present in `backend/BDRC/`
- [x] Existing OCR endpoint still works on a known-good PDF (smoke test)
- [x] `UPSTREAM.md` records the synced-from commit SHA and lists the cherry-picked fixes
- [x] No spellcheck or DOCX behavior changes

## Notes

**Deploy: prod**

Not stacked — branched directly off `feat/interactive-ocr`, no open PR dependencies.