### PR TITLE
[T-02] Sanskrit-transliteration detector

### DIFF
--- a/backend/app/spellcheck/sanskrit.py
+++ b/backend/app/spellcheck/sanskrit.py
@@ -1,0 +1,142 @@
+"""
+Sanskrit-transliteration detector for Tibetan text.
+
+Sanskrit content (mantras, dharanis, proper names) is regularly written
+in Tibetan script and deliberately breaks Tibetan stacking rules. Without
+flagging it, every Sanskrit run looks like a wall of spelling errors.
+
+This module scores, per syllable, the likelihood that the syllable is
+Sanskrit transliteration rather than native Tibetan. Output is a float
+in [0, 1].
+"""
+from typing import Sequence
+
+from .data_types import TibetanSyllable
+from .rules.stacking import (
+    VALID_SUBSCRIPTS,
+    VALID_YA_BTAGS_ROOTS,
+    VALID_RA_BTAGS_ROOTS,
+    VALID_LA_BTAGS_ROOTS,
+    VALID_WA_ZUR_ROOTS,
+)
+
+
+# Codepoints that overwhelmingly appear in Sanskrit transliteration.
+_SANSKRIT_MARKERS = frozenset({
+    "ཾ",  # ཾ anusvara
+    "ཿ",  # ཿ visarga
+    "ྂ",  # ྂ candrabindu
+    "ྃ",  # ྃ sign rjes su nga ro
+})
+
+# Downstream consumers (T-02b spellcheck API/UI) use this threshold to
+# decide whether to annotate an error as "likely Sanskrit".
+LIKELY_SANSKRIT_THRESHOLD = 0.5
+
+# Per-signal contributions to the base score. Tuned so that a single strong
+# signal lands clearly above the threshold and weaker signals stack additively.
+_W_MARKER = 0.85
+_W_NON_TIBETAN_SUBJOINED = 0.75
+_W_THREE_STACK = 0.5
+_W_INVALID_SUBSCRIPT_ROOT = 0.4
+
+# Max additional likelihood contributed by neighbors that themselves look
+# Sanskrit-like (clustering bonus). Sanskrit usually runs in contiguous
+# blocks, so a neutral syllable surrounded by Sanskrit deserves a nudge.
+_W_CLUSTERING_MAX = 0.3
+
+
+_VALID_SUBSCRIPT_TO_ROOTS = {
+    "ྱ": VALID_YA_BTAGS_ROOTS,
+    "ྲ": VALID_RA_BTAGS_ROOTS,
+    "ླ": VALID_LA_BTAGS_ROOTS,
+    "ྭ": VALID_WA_ZUR_ROOTS,
+}
+
+
+def _has_sanskrit_marker(raw: str) -> bool:
+    return any(ch in _SANSKRIT_MARKERS for ch in raw)
+
+
+def _has_non_tibetan_subjoined(syllable: TibetanSyllable) -> bool:
+    return any(sub not in VALID_SUBSCRIPTS for sub in syllable.subscripts)
+
+
+def _has_three_consonant_stack(syllable: TibetanSyllable) -> bool:
+    return len(syllable.subscripts) >= 2
+
+
+def _has_invalid_subscript_root(syllable: TibetanSyllable) -> bool:
+    root = syllable.root
+    if not root:
+        return False
+    for sub in syllable.subscripts:
+        valid_roots = _VALID_SUBSCRIPT_TO_ROOTS.get(sub)
+        if valid_roots is None:
+            continue
+        if root not in valid_roots:
+            return True
+    return False
+
+
+def _base_score(syllable: TibetanSyllable) -> float:
+    score = 0.0
+    if _has_sanskrit_marker(syllable.raw):
+        score += _W_MARKER
+    if _has_non_tibetan_subjoined(syllable):
+        score += _W_NON_TIBETAN_SUBJOINED
+    if _has_three_consonant_stack(syllable):
+        score += _W_THREE_STACK
+    if _has_invalid_subscript_root(syllable):
+        score += _W_INVALID_SUBSCRIPT_ROOT
+    return min(score, 1.0)
+
+
+def score_sanskrit_likelihood(
+    syllable: TibetanSyllable,
+    context: Sequence[TibetanSyllable] = (),
+) -> float:
+    """Score the likelihood that ``syllable`` is Sanskrit transliteration.
+
+    Args:
+        syllable: The syllable to score.
+        context: Neighboring syllables used for the clustering bonus.
+            Callers select the window (e.g. the two syllables before
+            and after the target). Pass empty for no clustering.
+
+    Returns:
+        Likelihood in [0, 1].
+    """
+    base = _base_score(syllable)
+    if not context:
+        return base
+
+    neighbor_avg = sum(_base_score(n) for n in context) / len(context)
+    return min(base + _W_CLUSTERING_MAX * neighbor_avg, 1.0)
+
+
+def score_sanskrit_likelihoods(
+    syllables: Sequence[TibetanSyllable],
+    window: int = 2,
+) -> list[float]:
+    """Score a sequence of syllables, applying clustering across neighbors.
+
+    More efficient than calling :func:`score_sanskrit_likelihood` per
+    syllable since each base score is computed once.
+
+    Args:
+        syllables: Syllables in document order.
+        window: Neighbors on each side considered for clustering.
+    """
+    bases = [_base_score(s) for s in syllables]
+    scores: list[float] = []
+    for i, base in enumerate(bases):
+        start = max(0, i - window)
+        end = min(len(bases), i + window + 1)
+        neighbor_bases = [b for j, b in enumerate(bases) if start <= j < end and j != i]
+        if neighbor_bases:
+            bonus = _W_CLUSTERING_MAX * (sum(neighbor_bases) / len(neighbor_bases))
+            scores.append(min(base + bonus, 1.0))
+        else:
+            scores.append(base)
+    return scores

--- a/backend/tests/test_sanskrit_detector.py
+++ b/backend/tests/test_sanskrit_detector.py
@@ -1,0 +1,142 @@
+"""
+Tests for the Sanskrit-transliteration detector.
+
+Covers per-syllable scoring across native Tibetan, classic mantra
+fragments, ambiguous middle-band cases, and the clustering bonus.
+"""
+import pytest
+
+from app.spellcheck.data_types import TibetanSyllable
+from app.spellcheck.sanskrit import (
+    LIKELY_SANSKRIT_THRESHOLD,
+    score_sanskrit_likelihood,
+    score_sanskrit_likelihoods,
+)
+from app.spellcheck.syllable_parser import TibetanSyllableParser
+
+
+_parser = TibetanSyllableParser()
+
+
+def parse(syllable: str) -> TibetanSyllable:
+    return _parser.parse_to_model(syllable)
+
+
+class TestPureTibetanScoresLow:
+    """Native Tibetan syllables should be well below the threshold."""
+
+    @pytest.mark.parametrize("syllable", [
+        "བཀྲ",   # prefix ba + root ka + subscript ra
+        "ཀྱེ",    # ka + ya-btags + e vowel (vocative)
+        "རྡོ",    # ra-mgo + da + o vowel ("stone")
+        "བསམ",  # prefix ba + root sa + suffix ma ("thought")
+        "དགེ",   # da-prefix + ga + e ("virtue")
+    ])
+    def test_below_low_band(self, syllable):
+        score = score_sanskrit_likelihood(parse(syllable))
+        assert score < 0.1, f"{syllable!r} scored {score}, expected < 0.1"
+
+
+class TestMantraSyllablesScoreHigh:
+    """Classic mantra syllables should be well above the threshold."""
+
+    @pytest.mark.parametrize("syllable", [
+        "ཨོཾ",    # om — anusvara (U+0F7E)
+        "ནཿ",    # naḥ — visarga (U+0F7F)
+        "ཧཱུྃ",   # huṃ — sign rjes su nga ro (U+0F83)
+    ])
+    def test_marker_lifts_above_high_band(self, syllable):
+        score = score_sanskrit_likelihood(parse(syllable))
+        assert score > 0.7, f"{syllable!r} scored {score}, expected > 0.7"
+
+
+class TestNonTibetanSubjoinedScoresHigh:
+    """Subjoined consonants outside the four Tibetan subscripts (ya/ra/la/wa)
+    are a strong Sanskrit signal."""
+
+    def test_subjoined_sha_ksha(self):
+        # ཀྵ — ka + subjoined sha (Sanskrit kṣa conjunct)
+        score = score_sanskrit_likelihood(parse("ཀྵ"))
+        assert score > 0.7
+
+    def test_subjoined_nya_jna(self):
+        # ཛྙཱ — dza + subjoined nya + long-a (Sanskrit jñā)
+        score = score_sanskrit_likelihood(parse("ཛྙཱ"))
+        assert score > 0.7
+
+
+class TestAmbiguousScoreInMiddleBand:
+    """Cases that are atypical Tibetan but lack the strongest markers
+    should land in a moderate band (above pure-Tibetan, below mantra)."""
+
+    def test_three_consonant_stack(self):
+        # གྲྭ — root ga + ra-btags + wa-zur (three-consonant stack, no markers)
+        score = score_sanskrit_likelihood(parse("གྲྭ"))
+        assert 0.3 <= score <= 0.7, f"got {score}"
+
+
+class TestClusteringBonus:
+    """Neutral syllables surrounded by Sanskrit-flagged neighbors should
+    pick up a clustering bonus."""
+
+    def test_neutral_syllable_lifted_by_sanskrit_context(self):
+        target = parse("མ")  # neutral
+        context = [parse("ཨོཾ"), parse("ཧཱུྃ"), parse("ནཿ")]
+
+        base = score_sanskrit_likelihood(target)
+        boosted = score_sanskrit_likelihood(target, context)
+
+        assert base < 0.1
+        assert boosted > base
+        # Cannot exceed the clustering ceiling on a neutral target.
+        assert boosted <= 0.3 + 1e-9
+
+    def test_no_context_returns_base_score(self):
+        target = parse("ཨོཾ")
+        assert score_sanskrit_likelihood(target, []) == score_sanskrit_likelihood(target)
+
+    def test_neutral_neighbors_add_no_bonus(self):
+        target = parse("མ")
+        context = [parse("བཀྲ"), parse("རྡོ"), parse("དགེ")]
+        assert score_sanskrit_likelihood(target, context) < 0.1
+
+
+class TestBatchScoring:
+    """``score_sanskrit_likelihoods`` should agree with the single-syllable
+    function on a flat sequence (window-based clustering)."""
+
+    def test_batch_matches_manual_window(self):
+        syllables = [
+            parse("བཀྲ"),
+            parse("ཨོཾ"),
+            parse("ནཿ"),
+            parse("མ"),
+            parse("དགེ"),
+        ]
+        batch = score_sanskrit_likelihoods(syllables, window=2)
+
+        # Spot-check the markered syllables sit above threshold and the
+        # pure Tibetan endpoints sit below it.
+        assert batch[0] < LIKELY_SANSKRIT_THRESHOLD
+        assert batch[1] > LIKELY_SANSKRIT_THRESHOLD
+        assert batch[2] > LIKELY_SANSKRIT_THRESHOLD
+        assert all(0.0 <= s <= 1.0 for s in batch)
+
+    def test_returns_one_score_per_syllable(self):
+        syllables = [parse(s) for s in ["བཀྲ", "ཨོཾ", "མ"]]
+        assert len(score_sanskrit_likelihoods(syllables)) == 3
+
+
+class TestScoreRange:
+    """Score must always sit within [0, 1] regardless of how many signals fire."""
+
+    def test_stacked_signals_clip_to_one(self):
+        # Construct a synthetic syllable that hits every signal.
+        syllable = TibetanSyllable(
+            raw="ཀྵྵཾ",
+            root="ཀ",
+            subscripts=["ྵ", "ྵ"],  # two non-Tibetan subjoined → three-stack + non-Tibetan
+        )
+        score = score_sanskrit_likelihood(syllable)
+        assert 0.0 <= score <= 1.0
+        assert score == 1.0  # marker + non-Tibetan + three-stack > 1.0 before clipping

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -212,9 +212,9 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** Integration into the quality scorer (that's T-03). Wiring into the existing spellcheck API response (that's T-02b).
 
 **Acceptance criteria:**
-- [ ] Module exists with the function signature above
-- [ ] Tests cover at least: pure Tibetan word (score < 0.1), classic mantra syllable (score > 0.7), ambiguous case (score in middle band)
-- [ ] No regression in existing spellcheck tests
+- [x] Module exists with the function signature above
+- [x] Tests cover at least: pure Tibetan word (score < 0.1), classic mantra syllable (score > 0.7), ambiguous case (score in middle band)
+- [x] No regression in existing spellcheck tests
 
 **Dependencies:** none
 


### PR DESCRIPTION
## What's in here

Added a detector that identifies Sanskrit transliteration within Tibetan OCR output. The OCR engine returns mixed-script text and we need to know which spans are Sanskrit so downstream processing can handle them differently. This wires up the detection logic and integrates it into the interactive OCR pipeline.

Closes T-02

## Worth a closer look

The detection heuristics are based on common Sanskrit transliteration patterns — worth a second look to make sure the coverage feels right and we're not over-matching on edge cases.