### PR TITLE
[T-02b] Wire Sanskrit detection into spellcheck API

### DIFF
--- a/backend/app/api/spellcheck.py
+++ b/backend/app/api/spellcheck.py
@@ -19,6 +19,7 @@ from app.schemas.spellcheck import (
     SpellCheckResponse,
 )
 from app.spellcheck.engine import TibetanSpellChecker
+from app.spellcheck.sanskrit import annotate_errors_with_sanskrit
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ async def check_text(request: SpellCheckRequest):
     """
     try:
         raw_errors = await asyncio.to_thread(_checker.check_text, request.text)
+        annotate_errors_with_sanskrit(request.text, raw_errors)
 
         errors = [
             ErrorResponse(
@@ -65,6 +67,8 @@ async def check_text(request: SpellCheckRequest):
                 message=error.get("message"),
                 component=error.get("component"),
                 corpus_hit=error.get("corpus_hit"),
+                sanskrit_likelihood=error.get("sanskrit_likelihood", 0.0),
+                likely_sanskrit=error.get("likely_sanskrit", False),
             )
             for error in raw_errors
         ]
@@ -305,6 +309,7 @@ def _run_spellcheck(pages) -> tuple[dict[int, list[str]], list[dict]]:
             continue
 
         raw_errors = checker.check_text(page.text)
+        annotate_errors_with_sanskrit(page.text, raw_errors)
 
         page_error_words = [e.get("word", "") for e in raw_errors if e.get("word")]
         if page_error_words:
@@ -320,6 +325,8 @@ def _run_spellcheck(pages) -> tuple[dict[int, list[str]], list[dict]]:
                     "message": e.get("message"),
                     "component": e.get("component"),
                     "corpus_hit": e.get("corpus_hit"),
+                    "sanskrit_likelihood": e.get("sanskrit_likelihood", 0.0),
+                    "likely_sanskrit": e.get("likely_sanskrit", False),
                 }
             )
 

--- a/backend/app/schemas/spellcheck.py
+++ b/backend/app/schemas/spellcheck.py
@@ -56,6 +56,21 @@ class ErrorResponse(BaseModel):
             "None means the corpus was not loaded."
         )
     )
+    sanskrit_likelihood: float = Field(
+        0.0,
+        description=(
+            "Likelihood [0, 1] that the offending syllable is Sanskrit transliteration "
+            "rather than native Tibetan. Mantras and dharanis deliberately break "
+            "Tibetan stacking rules; this signal lets the UI annotate likely-Sanskrit "
+            "errors with extra context without suppressing them."
+        ),
+        ge=0.0,
+        le=1.0,
+    )
+    likely_sanskrit: bool = Field(
+        False,
+        description="True when sanskrit_likelihood meets the detector's threshold.",
+    )
 
 
 class SpellCheckResponse(BaseModel):
@@ -96,6 +111,8 @@ class PDFErrorResponse(BaseModel):
     message: Optional[str] = None
     component: Optional[str] = None
     corpus_hit: Optional[bool] = None
+    sanskrit_likelihood: float = Field(0.0, ge=0.0, le=1.0)
+    likely_sanskrit: bool = False
 
 
 class PDFUploadSyncResponse(BaseModel):

--- a/backend/app/spellcheck/sanskrit.py
+++ b/backend/app/spellcheck/sanskrit.py
@@ -140,3 +140,56 @@ def score_sanskrit_likelihoods(
         else:
             scores.append(base)
     return scores
+
+
+def annotate_errors_with_sanskrit(text: str, errors: list[dict]) -> None:
+    """Decorate spellcheck error dicts in place with Sanskrit-likelihood fields.
+
+    Adds ``sanskrit_likelihood`` (float, rounded to 3 places) and
+    ``likely_sanskrit`` (bool) to each error. Errors that don't correspond
+    to a syllable in ``text`` (e.g. the synthetic ``non_tibetan_skipped``
+    summary with ``word=''``) are annotated with 0.0 / False.
+
+    Args:
+        text: The original text passed to the spell checker.
+        errors: Engine error dicts; each is expected to carry ``position``
+            (in original-text coordinates) and ``word``.
+    """
+    if not errors:
+        return
+
+    from .char_typing import type_characters
+    from .normalizer import (
+        is_tibetan_char,
+        normalize_tibetan,
+        normalize_tibetan_with_position_map,
+    )
+    from .parsing import parse_syllable
+    from .splitter import split_syllables_with_position
+
+    normalized, pos_map = normalize_tibetan_with_position_map(text)
+    syllable_items = split_syllables_with_position(normalized)
+
+    parsed_seq: list[TibetanSyllable] = []
+    score_keys: list[tuple[int, str]] = []
+    for item in syllable_items:
+        raw_syl = item["syllable"]
+        norm_pos = item["position"]
+        original_pos = pos_map[norm_pos] if norm_pos < len(pos_map) else norm_pos
+
+        if any(is_tibetan_char(c) for c in raw_syl):
+            normalized_syl = normalize_tibetan(raw_syl)
+            parsed_seq.append(parse_syllable(type_characters(normalized_syl)))
+        else:
+            parsed_seq.append(TibetanSyllable(raw=""))
+
+        score_keys.append((original_pos, raw_syl))
+
+    scores = score_sanskrit_likelihoods(parsed_seq)
+    score_by_key = dict(zip(score_keys, scores))
+
+    for err in errors:
+        key = (err.get("position", 0), err.get("word", ""))
+        score = score_by_key.get(key, 0.0)
+        err["sanskrit_likelihood"] = round(score, 3)
+        err["likely_sanskrit"] = score >= LIKELY_SANSKRIT_THRESHOLD

--- a/backend/tests/test_api_spellcheck.py
+++ b/backend/tests/test_api_spellcheck.py
@@ -194,12 +194,60 @@ class TestErrorResponseStructure:
             "/api/v1/spellcheck/text",
             json={"text": "གཀར"}
         )
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         for error in data["errors"]:
             assert error["severity"] in ["critical", "error", "info"]
+
+    def test_errors_include_sanskrit_fields(self):
+        """Every error should include sanskrit_likelihood and likely_sanskrit."""
+        response = client.post(
+            "/api/v1/spellcheck/text",
+            json={"text": "གཀར"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error_count"] > 0
+
+        for error in data["errors"]:
+            assert "sanskrit_likelihood" in error
+            assert "likely_sanskrit" in error
+            assert isinstance(error["sanskrit_likelihood"], float)
+            assert 0.0 <= error["sanskrit_likelihood"] <= 1.0
+            assert isinstance(error["likely_sanskrit"], bool)
+
+    def test_mantra_syllable_flagged_likely_sanskrit(self):
+        """A syllable with anusvara should be annotated likely_sanskrit=True."""
+        # ཨོཾ trips the engine's structural check (anusvara is unparsed) and
+        # is unambiguously Sanskrit transliteration.
+        response = client.post(
+            "/api/v1/spellcheck/text",
+            json={"text": "ཨོཾ"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        sanskrit_errors = [e for e in data["errors"] if e.get("likely_sanskrit")]
+        assert len(sanskrit_errors) >= 1
+        assert sanskrit_errors[0]["sanskrit_likelihood"] > 0.7
+
+    def test_pure_tibetan_error_not_flagged_sanskrit(self):
+        """A plain structural error should NOT be flagged as likely Sanskrit."""
+        response = client.post(
+            "/api/v1/spellcheck/text",
+            json={"text": "གཀར"}  # invalid prefix-root, no Sanskrit signals
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        spelling_errors = [e for e in data["errors"] if e["severity"] != "info"]
+        assert len(spelling_errors) >= 1
+        for error in spelling_errors:
+            assert error["likely_sanskrit"] is False
+            assert error["sanskrit_likelihood"] < 0.5
 
 
 class TestAPIDocumentation:

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -234,10 +234,10 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** Auto-accepting Sanskrit during spellcheck. Configuring the threshold per user.
 
 **Acceptance criteria:**
-- [ ] API response includes the new fields for every error
-- [ ] UI renders likely-Sanskrit errors visually distinct from regular errors
-- [ ] Existing spellcheck tests updated and passing; new test asserts the field is present
-- [ ] Pure-Tibetan misspellings still surface as normal errors (no false suppression)
+- [x] API response includes the new fields for every error
+- [x] UI renders likely-Sanskrit errors visually distinct from regular errors
+- [x] Existing spellcheck tests updated and passing; new test asserts the field is present
+- [x] Pure-Tibetan misspellings still surface as normal errors (no false suppression)
 
 **Dependencies:** T-02
 

--- a/frontend/components/spellcheck/ErrorDisplay.tsx
+++ b/frontend/components/spellcheck/ErrorDisplay.tsx
@@ -34,9 +34,19 @@ const SeverityBadge: React.FC<{ severity: string }> = ({ severity }) => {
   )
 }
 
-const errorUnderlineClass = (severity: string): string => {
-  if (severity === 'warning') return 'border-b-2 border-yellow-400 text-yellow-700 cursor-pointer'
+const errorUnderlineClass = (error: SpellCheckError): string => {
+  if (error.likely_sanskrit) {
+    return 'border-b-2 border-dotted border-purple-500 text-purple-700 cursor-pointer'
+  }
+  if (error.severity === 'warning') {
+    return 'border-b-2 border-yellow-400 text-yellow-700 cursor-pointer'
+  }
   return 'border-b-2 border-red-500 text-red-700 cursor-pointer'
+}
+
+const tooltipText = (error: SpellCheckError): string => {
+  const base = formatErrorType(error.error_type) + (error.message ? ` — ${error.message}` : '')
+  return error.likely_sanskrit ? `${base} · likely Sanskrit transliteration` : base
 }
 
 const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
@@ -83,12 +93,11 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
             key={`error-${currentErrorStart}`}
             className="relative inline-block group"
           >
-            <span className={errorUnderlineClass(currentError.severity)}>
+            <span className={errorUnderlineClass(currentError)}>
               {chars.slice(currentErrorStart, i).join('')}
             </span>
             <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
-              {formatErrorType(currentError.error_type)}
-              {currentError.message && ` — ${currentError.message}`}
+              {tooltipText(currentError)}
             </span>
           </span>
         )
@@ -101,12 +110,11 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
           key={`error-${currentErrorStart}`}
           className="relative inline-block group"
         >
-          <span className={errorUnderlineClass(currentError.severity)}>
+          <span className={errorUnderlineClass(currentError)}>
             {chars.slice(currentErrorStart, i).join('')}
           </span>
           <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
-            {formatErrorType(currentError.error_type)}
-            {currentError.message && ` — ${currentError.message}`}
+            {tooltipText(currentError)}
           </span>
         </span>
       )
@@ -129,12 +137,11 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
         key={`error-${currentErrorStart}`}
         className="relative inline-block group"
       >
-        <span className={errorUnderlineClass(currentError.severity)}>
+        <span className={errorUnderlineClass(currentError)}>
           {chars.slice(currentErrorStart).join('')}
         </span>
         <span className="invisible group-hover:visible absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-xs bg-gray-900 text-white rounded shadow-lg whitespace-nowrap">
-          {formatErrorType(currentError.error_type)}
-          {currentError.message && ` — ${currentError.message}`}
+          {tooltipText(currentError)}
         </span>
       </span>
     )
@@ -148,7 +155,7 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
       >
         {elements}
       </div>
-      <div className="flex gap-4 text-xs text-gray-500">
+      <div className="flex flex-wrap gap-4 text-xs text-gray-500">
         <span className="flex items-center gap-1.5">
           <span className="inline-block w-4 border-b-2 border-red-500" />
           Structural error
@@ -156,6 +163,10 @@ const AnnotatedText: React.FC<{ text: string; errors: SpellCheckError[] }> = ({
         <span className="flex items-center gap-1.5">
           <span className="inline-block w-4 border-b-2 border-yellow-400" />
           Not found in word corpus
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-4 border-b-2 border-dotted border-purple-500" />
+          Likely Sanskrit transliteration
         </span>
       </div>
     </div>
@@ -288,7 +299,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ response }) => {
             <div className="flex flex-col gap-3">
               <div className="flex items-start justify-between">
                 <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-2">
+                  <div className="flex items-center gap-2 mb-2 flex-wrap">
                     <span
                       className="text-2xl font-semibold text-gray-900"
                       style={{ fontFamily: 'Jomolhari, serif' }}
@@ -296,6 +307,14 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ response }) => {
                       {error.word}
                     </span>
                     <SeverityBadge severity={error.severity} />
+                    {error.likely_sanskrit && (
+                      <span
+                        className="inline-block px-2 py-1 text-xs font-medium rounded border bg-purple-100 text-purple-800 border-purple-200"
+                        title="Likely Sanskrit transliteration — this syllable deliberately breaks Tibetan stacking rules"
+                      >
+                        LIKELY SANSKRIT
+                      </span>
+                    )}
                   </div>
                   <p className="text-sm text-gray-700 font-medium">
                     {formatErrorType(error.error_type)}

--- a/frontend/components/spellcheck/__tests__/ErrorDisplay.test.tsx
+++ b/frontend/components/spellcheck/__tests__/ErrorDisplay.test.tsx
@@ -159,6 +159,33 @@ describe('ErrorDisplay', () => {
     expect(checkIcon).toBeInTheDocument()
   })
 
+  it('renders likely-Sanskrit errors with a distinct purple badge and dotted underline', () => {
+    const sanskritError: SpellCheckError = {
+      word: 'ཨོཾ',
+      position: 0,
+      error_type: 'unparsed_characters',
+      severity: 'error',
+      message: "Characters 'ཾ' could not be assigned to any syllable component",
+      sanskrit_likelihood: 0.85,
+      likely_sanskrit: true,
+    }
+
+    const {container} = render(
+      <ErrorDisplay
+        response={{
+          text: 'ཨོཾ་',
+          error_count: 1,
+          errors: [sanskritError],
+        }}
+      />,
+    )
+
+    expect(screen.getByText('LIKELY SANSKRIT')).toBeInTheDocument()
+    expect(container.querySelector('.border-dotted.border-purple-500')).toBeInTheDocument()
+    // Both the inline tooltip and the legend mention "Likely Sanskrit transliteration".
+    expect(screen.getAllByText(/likely sanskrit transliteration/i).length).toBeGreaterThan(0)
+  })
+
   it('filters out info messages from error display', () => {
     const withInfoResponse: SpellCheckResponse = {
       text: 'བོད་ABC',

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,6 +12,8 @@ export interface SpellCheckError {
   message?: string
   component?: string
   corpus_hit?: boolean | null
+  sanskrit_likelihood?: number
+  likely_sanskrit?: boolean
 }
 
 export interface SpellCheckResponse {
@@ -95,6 +97,8 @@ export interface PDFSpellError {
   message?: string
   component?: string
   corpus_hit?: boolean | null
+  sanskrit_likelihood?: number
+  likely_sanskrit?: boolean
 }
 
 export interface PDFUploadSyncResponse {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,7 +2,7 @@
  * API client for Tibetan Spell Checker backend
  */
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
 
 export interface SpellCheckError {
   word: string

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,22 @@
 /** @type {import('next').NextConfig} */
+// In dev, proxy /api/* to the local backend so the browser stays same-origin
+// (avoids the CORS preflight that fails when NEXT_PUBLIC_API_URL points cross-origin).
+// In prod, NEXT_PUBLIC_API_URL is set at build time and fetched directly.
+const isDev = process.env.NODE_ENV === 'development'
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  ...(isDev && {
+    async rewrites() {
+      return [
+        {
+          source: '/api/:path*',
+          destination: 'http://localhost:8000/api/:path*',
+        },
+      ]
+    },
+  }),
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## What's in here

Connects the Sanskrit detector (landed in 93d4383) to the live spellcheck API so that errors on likely-Sanskrit syllables — mantras, dharanis, etc. — come back with `likely_sanskrit: true` and a `sanskrit_likelihood` score. The frontend now renders those in purple with a dotted underline and a "LIKELY SANSKRIT" badge, instead of treating them the same as structural Tibetan errors. See the Interactive OCR Plan (`docs/planning/INTERACTIVE_OCR_PLAN.md`) for where this fits in the broader T-02 work.

Also bundled in: a small Next.js dev rewrite that proxies `/api/*` to `localhost:8000`, which sidesteps a CORS preflight issue that was making local development annoying. No prod behavior change.

## Worth a closer look

The annotation is done as a post-pass over the raw error list (`annotate_errors_with_sanskrit`) rather than inside the spell-check engine itself — keeps the Sanskrit logic decoupled. The threshold that flips `likely_sanskrit` to true lives in `sanskrit.py`; worth a look if the false-positive rate feels off during review.