### PR TITLE
[T-03] Add page quality scorer for interactive OCR workflow

### DIFF
--- a/backend/app/ocr_assist/quality.py
+++ b/backend/app/ocr_assist/quality.py
@@ -33,7 +33,7 @@ substitution can score well structurally while being silently wrong.
 from dataclasses import dataclass
 from typing import Literal, Sequence
 
-from app.spellcheck.normalizer import is_tibetan_char
+from app.spellcheck.normalizer import is_tibetan_char, normalize_tibetan
 from app.spellcheck.sanskrit import (
     LIKELY_SANSKRIT_THRESHOLD,
     score_sanskrit_likelihoods,
@@ -211,7 +211,7 @@ def _line_count_sanity(diagnostics: OcrDiagnostics) -> float:
 
 
 def _split_tibetan_syllables(text: str) -> list[str]:
-    return [s for s in split_syllables(text) if any(is_tibetan_char(c) for c in s)]
+    return [s for s in split_syllables(normalize_tibetan(text)) if any(is_tibetan_char(c) for c in s)]
 
 
 def _sanskrit_words(tibetan_syllables: Sequence[str]) -> set[str]:

--- a/backend/app/ocr_assist/quality.py
+++ b/backend/app/ocr_assist/quality.py
@@ -33,12 +33,15 @@ substitution can score well structurally while being silently wrong.
 from dataclasses import dataclass
 from typing import Literal, Sequence
 
-from app.spellcheck.normalizer import is_tibetan_char, normalize_tibetan
+from app.spellcheck.normalizer import (
+    is_tibetan_char,
+    normalize_tibetan_with_position_map,
+)
 from app.spellcheck.sanskrit import (
     LIKELY_SANSKRIT_THRESHOLD,
     score_sanskrit_likelihoods,
 )
-from app.spellcheck.splitter import split_syllables
+from app.spellcheck.splitter import split_syllables_with_position
 from app.spellcheck.syllable_parser import TibetanSyllableParser
 
 
@@ -88,6 +91,13 @@ class Thresholds:
     accept: float
     reject: float
 
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.reject <= self.accept <= 1.0:
+            raise ValueError(
+                "Thresholds must satisfy 0.0 <= reject <= accept <= 1.0; "
+                f"got accept={self.accept}, reject={self.reject}"
+            )
+
 
 @dataclass(frozen=True)
 class PageQuality:
@@ -119,6 +129,11 @@ def score_page(
     tibetan_syllables = _split_tibetan_syllables(ocr_text)
     total = len(tibetan_syllables)
 
+    # encoding_error is intentionally NOT excluded here: it is severity
+    # "critical" and not a Phase-2 type, so it counts (1.5x) toward the
+    # structural / sanskrit-adjusted ratio *and* separately trips the hard
+    # floor in decide(). It is genuinely both a structural defect and a
+    # silent-substitution risk, so the double-count is deliberate.
     structural_errors = [
         e for e in spellcheck_result
         if e.get("error_type") not in _PHASE2_ERROR_TYPES
@@ -128,10 +143,18 @@ def score_page(
 
     structural_ratio = _ratio(_weighted_error_score(structural_errors), total)
 
-    sanskrit_words = _sanskrit_words(tibetan_syllables)
-    sanskrit_adjusted_errors = [
-        e for e in structural_errors if e.get("word") not in sanskrit_words
-    ]
+    # The per-syllable Sanskrit parse/score is only needed to strip Sanskrit
+    # errors out of the structural numerator. On a clean page (no structural
+    # errors — the common case in the retry loop) there is nothing to strip,
+    # so skip the work entirely.
+    if structural_errors:
+        sanskrit_positions, sanskrit_words = _sanskrit_syllables(tibetan_syllables)
+        sanskrit_adjusted_errors = [
+            e for e in structural_errors
+            if not _is_sanskrit_error(e, sanskrit_positions, sanskrit_words)
+        ]
+    else:
+        sanskrit_adjusted_errors = []
     sanskrit_adjusted_ratio = _ratio(
         _weighted_error_score(sanskrit_adjusted_errors), total
     )
@@ -210,17 +233,66 @@ def _line_count_sanity(diagnostics: OcrDiagnostics) -> float:
     return max(0.0, 1.0 - deviation)
 
 
-def _split_tibetan_syllables(text: str) -> list[str]:
-    return [s for s in split_syllables(normalize_tibetan(text)) if any(is_tibetan_char(c) for c in s)]
+def _split_tibetan_syllables(text: str) -> list[tuple[str, int]]:
+    """Tibetan-only syllables paired with their position in the *original* text.
+
+    Mirrors ``TibetanSpellChecker.check_text``: normalize (NFC + zero-width
+    strip) before splitting, then map each syllable's offset back to a position
+    in the original text so it lines up with the ``position`` recorded on
+    spellcheck errors (``engine.py:182,195``). Normalizing first also keeps the
+    syllable strings byte-equal to the error ``word`` values for the fallback
+    match.
+    """
+    normalized, pos_map = normalize_tibetan_with_position_map(text)
+    syllables: list[tuple[str, int]] = []
+    for item in split_syllables_with_position(normalized):
+        syl = item["syllable"]
+        if not any(is_tibetan_char(c) for c in syl):
+            continue
+        norm_pos = item["position"]
+        mapped = pos_map[norm_pos] if norm_pos < len(pos_map) else norm_pos
+        syllables.append((syl, mapped))
+    return syllables
 
 
-def _sanskrit_words(tibetan_syllables: Sequence[str]) -> set[str]:
+def _sanskrit_syllables(
+    tibetan_syllables: Sequence[tuple[str, int]],
+) -> tuple[set[int], set[str]]:
+    """Positions and strings of Sanskrit-likely syllables on the page.
+
+    The Sanskrit scorer is context-sensitive (a syllable's score gets a
+    clustering bonus from its neighbours), so the page is scored as one ordered
+    sequence. Returns both the set of original-text positions (for the
+    position-aware exclusion) and the set of syllable strings (a fallback for
+    errors that carry no position).
+    """
     if not tibetan_syllables:
-        return set()
-    parsed = [_parser.parse_to_model(s) for s in tibetan_syllables]
+        return set(), set()
+    syls = [s for s, _ in tibetan_syllables]
+    parsed = [_parser.parse_to_model(s) for s in syls]
     likelihoods = score_sanskrit_likelihoods(parsed)
-    return {
-        syl
-        for syl, score in zip(tibetan_syllables, likelihoods)
-        if score >= LIKELY_SANSKRIT_THRESHOLD
-    }
+    positions: set[int] = set()
+    words: set[str] = set()
+    for (syl, pos), score in zip(tibetan_syllables, likelihoods):
+        if score >= LIKELY_SANSKRIT_THRESHOLD:
+            positions.add(pos)
+            words.add(syl)
+    return positions, words
+
+
+def _is_sanskrit_error(
+    error: dict,
+    sanskrit_positions: set[int],
+    sanskrit_words: set[str],
+) -> bool:
+    """Whether a structural error sits on a Sanskrit-likely syllable.
+
+    Prefers a position match (precise — a syllable flagged Sanskrit inside a
+    mantra no longer suppresses a genuine error on the same string elsewhere).
+    Falls back to string match for errors that carry no ``position`` (e.g.
+    hand-crafted inputs in unit tests).
+    """
+    position = error.get("position")
+    if position is not None:
+        return position in sanskrit_positions
+    return error.get("word") in sanskrit_words

--- a/backend/app/ocr_assist/quality.py
+++ b/backend/app/ocr_assist/quality.py
@@ -1,0 +1,226 @@
+"""
+Per-page OCR quality scorer for the interactive OCR workflow.
+
+Drives the accept/escalate/reject decision in the per-page retry loop
+(see ``docs/planning/INTERACTIVE_OCR_PLAN.md`` § T-03).
+
+Composite formula
+-----------------
+
+Each signal contributes a "badness" in [0, 1]. The composite is::
+
+    badness = (
+        W_NON_TIBETAN * non_tibetan_char_ratio
+      + W_STRUCTURAL  * sanskrit_adjusted_error_ratio
+      + W_LINE_SANITY * (1.0 - line_count_sanity)
+      + W_PHASE2_UNKNOWN * unknown_word_ratio
+    )
+    composite_score = max(0.0, 1.0 - badness)
+
+The sanskrit-adjusted error ratio is used (not the raw structural ratio)
+so legitimate Sanskrit blocks — which deliberately break Tibetan stacking
+rules — don't dominate the penalty.
+
+Phase-2 (corpus lookup) input is captured as ``unknown_word_ratio`` and is
+present in the composite with weight ``W_PHASE2_UNKNOWN = 0.0`` until the
+word corpus is populated. The signature does not need to change when
+Phase 2 is enabled — only the weight.
+
+Encoding errors are a hard floor: any non-zero count blocks ``accept`` in
+``decide`` regardless of the composite score, because a wrong-codepoint
+substitution can score well structurally while being silently wrong.
+"""
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+from app.spellcheck.normalizer import is_tibetan_char
+from app.spellcheck.sanskrit import (
+    LIKELY_SANSKRIT_THRESHOLD,
+    score_sanskrit_likelihoods,
+)
+from app.spellcheck.splitter import split_syllables
+from app.spellcheck.syllable_parser import TibetanSyllableParser
+
+
+# Composite weights. Tuned so a clean page scores near 1.0 and a heavily
+# corrupted page scores near 0. Weights are configurable here, not per-call.
+W_NON_TIBETAN: float = 0.25
+W_STRUCTURAL: float = 0.50
+W_LINE_SANITY: float = 0.25
+# TODO(phase-2): raise above 0 once the word corpus is populated.
+W_PHASE2_UNKNOWN: float = 0.0
+
+
+# Severity → weight multiplier for the structural error ratio numerator.
+# Critical errors (encoding errors) count harder than ordinary structural
+# errors; warnings (excluding Phase 2 unknown_word) count half.
+_SEVERITY_WEIGHT: dict[str, float] = {
+    "critical": 1.5,
+    "error": 1.0,
+    "warning": 0.5,
+    "info": 0.0,
+}
+
+# Phase-2 errors are tracked separately, not folded into the Phase-1 ratio.
+_PHASE2_ERROR_TYPES: frozenset[str] = frozenset({"unknown_word"})
+
+
+@dataclass(frozen=True)
+class OcrDiagnostics:
+    """OCR-level signals supplied by the BDRC runner.
+
+    ``expected_line_count`` is optional — pass ``None`` to skip the line
+    sanity check (e.g. on the first page of a job where there's no baseline
+    to compare against yet).
+    """
+    line_count: int = 0
+    expected_line_count: int | None = None
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    """Decision boundaries on the composite score.
+
+    A page with composite >= ``accept`` auto-passes. A page below ``reject``
+    is too damaged to retry profitably and is queued for human review.
+    Pages in between go through the AI retry loop.
+    """
+    accept: float
+    reject: float
+
+
+@dataclass(frozen=True)
+class PageQuality:
+    non_tibetan_char_ratio: float
+    structural_error_ratio: float
+    sanskrit_adjusted_error_ratio: float
+    line_count_sanity: float
+    encoding_error_count: int
+    unknown_word_ratio: float
+    composite_score: float
+    breakdown: dict[str, float]
+
+
+_parser = TibetanSyllableParser()
+
+
+def score_page(
+    ocr_text: str,
+    spellcheck_result: Sequence[dict],
+    ocr_diagnostics: OcrDiagnostics,
+) -> PageQuality:
+    """Compute quality signals + composite for a single OCR'd page.
+
+    ``spellcheck_result`` is the output of ``TibetanSpellChecker.check_text``;
+    both Phase-1 structural errors and Phase-2 ``unknown_word`` errors may be
+    present. Phase 2 entries are surfaced as ``unknown_word_ratio`` but are
+    weighted at 0 in the composite for now.
+    """
+    tibetan_syllables = _split_tibetan_syllables(ocr_text)
+    total = len(tibetan_syllables)
+
+    structural_errors = [
+        e for e in spellcheck_result
+        if e.get("error_type") not in _PHASE2_ERROR_TYPES
+        and e.get("severity") != "info"
+    ]
+    unknown_errors = [e for e in spellcheck_result if e.get("error_type") == "unknown_word"]
+
+    structural_ratio = _ratio(_weighted_error_score(structural_errors), total)
+
+    sanskrit_words = _sanskrit_words(tibetan_syllables)
+    sanskrit_adjusted_errors = [
+        e for e in structural_errors if e.get("word") not in sanskrit_words
+    ]
+    sanskrit_adjusted_ratio = _ratio(
+        _weighted_error_score(sanskrit_adjusted_errors), total
+    )
+
+    non_tibetan_ratio = _non_tibetan_char_ratio(ocr_text)
+    line_sanity = _line_count_sanity(ocr_diagnostics)
+    encoding_errors = sum(
+        1 for e in spellcheck_result if e.get("error_type") == "encoding_error"
+    )
+    unknown_ratio = _ratio(len(unknown_errors), total)
+
+    breakdown = {
+        "non_tibetan_penalty": W_NON_TIBETAN * non_tibetan_ratio,
+        "structural_penalty": W_STRUCTURAL * sanskrit_adjusted_ratio,
+        "line_sanity_penalty": W_LINE_SANITY * (1.0 - line_sanity),
+        "phase2_penalty": W_PHASE2_UNKNOWN * unknown_ratio,
+    }
+    composite = max(0.0, 1.0 - sum(breakdown.values()))
+
+    return PageQuality(
+        non_tibetan_char_ratio=non_tibetan_ratio,
+        structural_error_ratio=structural_ratio,
+        sanskrit_adjusted_error_ratio=sanskrit_adjusted_ratio,
+        line_count_sanity=line_sanity,
+        encoding_error_count=encoding_errors,
+        unknown_word_ratio=unknown_ratio,
+        composite_score=composite,
+        breakdown=breakdown,
+    )
+
+
+def decide(
+    quality: PageQuality,
+    thresholds: Thresholds,
+) -> Literal["accept", "escalate", "reject"]:
+    """Bucket a page: auto-accept, escalate to AI retry, or queue for human."""
+    if quality.encoding_error_count > 0:
+        if quality.composite_score < thresholds.reject:
+            return "reject"
+        return "escalate"
+
+    if quality.composite_score >= thresholds.accept:
+        return "accept"
+    if quality.composite_score < thresholds.reject:
+        return "reject"
+    return "escalate"
+
+
+def _ratio(numerator: float, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return min(numerator / denominator, 1.0)
+
+
+def _weighted_error_score(errors: Sequence[dict]) -> float:
+    return sum(
+        _SEVERITY_WEIGHT.get(e.get("severity", "error"), 1.0) for e in errors
+    )
+
+
+def _non_tibetan_char_ratio(text: str) -> float:
+    total = sum(1 for ch in text if not ch.isspace())
+    if total == 0:
+        return 0.0
+    non_tibetan = sum(
+        1 for ch in text if not ch.isspace() and not is_tibetan_char(ch)
+    )
+    return non_tibetan / total
+
+
+def _line_count_sanity(diagnostics: OcrDiagnostics) -> float:
+    expected = diagnostics.expected_line_count
+    if expected is None or expected <= 0:
+        return 1.0
+    deviation = abs(diagnostics.line_count - expected) / expected
+    return max(0.0, 1.0 - deviation)
+
+
+def _split_tibetan_syllables(text: str) -> list[str]:
+    return [s for s in split_syllables(text) if any(is_tibetan_char(c) for c in s)]
+
+
+def _sanskrit_words(tibetan_syllables: Sequence[str]) -> set[str]:
+    if not tibetan_syllables:
+        return set()
+    parsed = [_parser.parse_to_model(s) for s in tibetan_syllables]
+    likelihoods = score_sanskrit_likelihoods(parsed)
+    return {
+        syl
+        for syl, score in zip(tibetan_syllables, likelihoods)
+        if score >= LIKELY_SANSKRIT_THRESHOLD
+    }

--- a/backend/tests/test_quality_scorer.py
+++ b/backend/tests/test_quality_scorer.py
@@ -10,6 +10,8 @@ Covers each signal and each branch of ``decide``:
 - Phase-2 unknown_word_ratio captured but currently weighted 0
 - decide → accept / escalate / reject branches
 """
+import unicodedata
+
 import pytest
 
 from app.ocr_assist.quality import (
@@ -155,6 +157,52 @@ class TestDecide:
     def test_boundary_at_reject_threshold(self):
         # composite == reject threshold → escalate (strict <)
         assert decide(self._q(0.5), self.THRESHOLDS) == "escalate"
+
+
+class TestNormalizationRoundtrip:
+    """Integration: check_text output must match score_page syllable splitting.
+
+    check_text normalizes (NFC + ZW strip) before splitting, so error['word']
+    values are normalized.  score_page must normalize ocr_text the same way
+    before splitting so that Sanskrit-syllable lookup works on non-NFC/ZW input.
+    """
+
+    def test_zw_prefixed_sanskrit_excluded_from_adjusted_ratio(self):
+        # ཨོཾ is a Sanskrit indicator syllable (anusvara U+0F7E).
+        # Inject a zero-width space before it to simulate non-clean OCR output.
+        # check_text strips the ZWS and returns word='ཨོཾ' in any error;
+        # score_page must also strip ZWS so the syllable set contains 'ཨོཾ'.
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        zws = '​'
+        sanskrit_syl = 'ཨོཾ'
+        plain_syl = 'བཀྲ'
+        raw_text = f'{zws}{sanskrit_syl}་{plain_syl}་ཤིས།'
+
+        checker = TibetanSpellChecker()
+        spellcheck_result = checker.check_text(raw_text)
+
+        synthetic_errors = [
+            {'word': sanskrit_syl, 'error_type': 'invalid_subscript_combination', 'severity': 'error'},
+            {'word': plain_syl,    'error_type': 'invalid_subscript_combination', 'severity': 'error'},
+        ]
+        combined = list(spellcheck_result) + synthetic_errors
+        quality = score_page(raw_text, combined, OcrDiagnostics())
+
+        # The Sanskrit syllable should be excluded → adjusted ratio < structural ratio.
+        assert quality.sanskrit_adjusted_error_ratio < quality.structural_error_ratio
+
+    def test_non_nfc_text_matches_check_text_words(self):
+        # Build NFD text and confirm score_page handles it without exceptions
+        # and produces a valid composite (no KeyError from mismatched word forms).
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        nfd_text = unicodedata.normalize('NFD', 'བཀྲ་ཤིས།')
+        checker = TibetanSpellChecker()
+        spellcheck_result = checker.check_text(nfd_text)
+
+        quality = score_page(nfd_text, spellcheck_result, OcrDiagnostics())
+        assert 0.0 <= quality.composite_score <= 1.0
 
 
 class TestEmptyText:

--- a/backend/tests/test_quality_scorer.py
+++ b/backend/tests/test_quality_scorer.py
@@ -73,6 +73,78 @@ class TestSanskritAdjustment:
         assert quality.sanskrit_adjusted_error_ratio > 0.0
 
 
+class TestSanskritExclusionPositionAware:
+    """The position-aware exclusion (`_is_sanskrit_error`).
+
+    A syllable flagged Sanskrit-likely at one position must not suppress a
+    genuine error on the same syllable string at a different (non-Sanskrit)
+    position. When an error carries no position, fall back to string matching.
+    """
+
+    def test_position_match_takes_precedence_over_word(self):
+        from app.ocr_assist.quality import _is_sanskrit_error
+
+        positions = {5}
+        words = {"ཨོཾ"}
+
+        # Same word string, two positions → different verdicts.
+        on_sanskrit = {"word": "ཨོཾ", "position": 5}
+        off_sanskrit = {"word": "ཨོཾ", "position": 99}
+        assert _is_sanskrit_error(on_sanskrit, positions, words) is True
+        assert _is_sanskrit_error(off_sanskrit, positions, words) is False
+
+    def test_falls_back_to_word_when_no_position(self):
+        from app.ocr_assist.quality import _is_sanskrit_error
+
+        positions = {5}
+        words = {"ཨོཾ"}
+        assert _is_sanskrit_error({"word": "ཨོཾ"}, positions, words) is True
+        assert _is_sanskrit_error({"word": "བཀྲ"}, positions, words) is False
+
+    def test_real_check_text_positions_exclude_sanskrit(self):
+        # End-to-end: real check_text errors carry positions; a Sanskrit
+        # syllable's error is excluded, a plain one is not.
+        from app.spellcheck.engine import TibetanSpellChecker
+
+        text = "ཨོཾ་མ་ཎི།\nབཀྲ་ཤིས།"
+        checker = TibetanSpellChecker()
+        real_errors = checker.check_text(text)
+        # Guard: only meaningful if check_text actually flags something here.
+        quality = score_page(text, real_errors, OcrDiagnostics())
+        assert quality.sanskrit_adjusted_error_ratio <= quality.structural_error_ratio
+        assert 0.0 <= quality.composite_score <= 1.0
+
+
+class TestCleanPageSkipsSanskritWork:
+    def test_no_structural_errors_skips_sanskrit_scoring(self, monkeypatch):
+        # On a clean page the (expensive) per-syllable Sanskrit parse/score
+        # must not run. Make it explode if called, then score a clean page.
+        import app.ocr_assist.quality as quality_mod
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("_sanskrit_syllables should not run on a clean page")
+
+        monkeypatch.setattr(quality_mod, "_sanskrit_syllables", _boom)
+        q = quality_mod.score_page(CLEAN_TEXT, [], OcrDiagnostics())
+        assert q.sanskrit_adjusted_error_ratio == 0.0
+        assert q.composite_score > 0.95
+
+
+class TestThresholdsValidation:
+    def test_equal_accept_and_reject_is_allowed(self):
+        Thresholds(accept=0.5, reject=0.5)  # no raise
+
+    def test_inverted_thresholds_raise(self):
+        with pytest.raises(ValueError):
+            Thresholds(accept=0.5, reject=0.8)
+
+    def test_out_of_range_thresholds_raise(self):
+        with pytest.raises(ValueError):
+            Thresholds(accept=1.2, reject=0.5)
+        with pytest.raises(ValueError):
+            Thresholds(accept=0.5, reject=-0.1)
+
+
 class TestLineSanity:
     def test_no_expected_line_count_skips_check(self):
         q = score_page(CLEAN_TEXT, [], OcrDiagnostics(line_count=3, expected_line_count=None))

--- a/backend/tests/test_quality_scorer.py
+++ b/backend/tests/test_quality_scorer.py
@@ -1,0 +1,167 @@
+"""
+Tests for the per-page OCR quality scorer.
+
+Covers each signal and each branch of ``decide``:
+- non_tibetan_char_ratio
+- structural_error_ratio
+- sanskrit_adjusted_error_ratio (Sanskrit-flagged errors excluded)
+- line_count_sanity
+- encoding_error_count hard floor
+- Phase-2 unknown_word_ratio captured but currently weighted 0
+- decide → accept / escalate / reject branches
+"""
+import pytest
+
+from app.ocr_assist.quality import (
+    OcrDiagnostics,
+    PageQuality,
+    Thresholds,
+    W_PHASE2_UNKNOWN,
+    decide,
+    score_page,
+)
+
+
+# A pure-Tibetan, mostly-clean page used as a baseline in several tests.
+CLEAN_TEXT = "བཀྲ་ཤིས་བདེ་ལེགས།\nདགེ་བའི་བཤེས་གཉེན།"
+
+
+def err(word: str, error_type: str = "invalid_subscript_combination", severity: str = "error") -> dict:
+    return {"word": word, "error_type": error_type, "severity": severity}
+
+
+class TestSignals:
+    def test_clean_page_scores_near_one(self):
+        quality = score_page(CLEAN_TEXT, [], OcrDiagnostics())
+        assert quality.composite_score > 0.95
+        assert quality.structural_error_ratio == 0.0
+        assert quality.non_tibetan_char_ratio == 0.0
+        assert quality.encoding_error_count == 0
+
+    def test_non_tibetan_chars_lower_score(self):
+        garbled = CLEAN_TEXT + " hello world XXXXXX"
+        quality = score_page(garbled, [], OcrDiagnostics())
+        assert quality.non_tibetan_char_ratio > 0.3
+        assert quality.composite_score < score_page(CLEAN_TEXT, [], OcrDiagnostics()).composite_score
+
+    def test_structural_errors_lower_score(self):
+        errors = [err("བཀྲ"), err("ཤིས"), err("བདེ")]
+        quality = score_page(CLEAN_TEXT, errors, OcrDiagnostics())
+        assert quality.structural_error_ratio > 0.0
+        assert quality.composite_score < 1.0
+
+    def test_critical_severity_weighs_more_than_error(self):
+        crit_q = score_page(CLEAN_TEXT, [err("བཀྲ", severity="critical")], OcrDiagnostics())
+        err_q = score_page(CLEAN_TEXT, [err("བཀྲ", severity="error")], OcrDiagnostics())
+        assert crit_q.structural_error_ratio > err_q.structural_error_ratio
+
+
+class TestSanskritAdjustment:
+    def test_sanskrit_flagged_errors_excluded_from_adjusted_ratio(self):
+        # ཨོཾ contains anusvara (U+0F7E) → Sanskrit detector flags it.
+        # ཀྲྀ uses a vocalic-r vowel; included as a non-Sanskrit error for contrast.
+        text = "ཨོཾ་མ་ཎི།\nབཀྲ་ཤིས།"
+        errors = [
+            err("ཨོཾ"),       # should be excluded from sanskrit-adjusted
+            err("བཀྲ"),      # pure Tibetan; stays in adjusted
+        ]
+        quality = score_page(text, errors, OcrDiagnostics())
+        # Raw structural ratio reflects both errors; adjusted reflects only one.
+        assert quality.sanskrit_adjusted_error_ratio < quality.structural_error_ratio
+        assert quality.sanskrit_adjusted_error_ratio > 0.0
+
+
+class TestLineSanity:
+    def test_no_expected_line_count_skips_check(self):
+        q = score_page(CLEAN_TEXT, [], OcrDiagnostics(line_count=3, expected_line_count=None))
+        assert q.line_count_sanity == 1.0
+
+    def test_line_count_matches_expected_is_perfect(self):
+        q = score_page(CLEAN_TEXT, [], OcrDiagnostics(line_count=8, expected_line_count=8))
+        assert q.line_count_sanity == 1.0
+
+    def test_line_count_deviates_lowers_sanity(self):
+        q = score_page(CLEAN_TEXT, [], OcrDiagnostics(line_count=4, expected_line_count=8))
+        assert q.line_count_sanity == pytest.approx(0.5)
+
+    def test_extreme_line_count_floors_at_zero(self):
+        q = score_page(CLEAN_TEXT, [], OcrDiagnostics(line_count=0, expected_line_count=2))
+        # |0-2|/2 = 1.0 deviation → sanity = 0.0
+        assert q.line_count_sanity == 0.0
+
+
+class TestEncodingErrors:
+    def test_encoding_errors_counted(self):
+        errors = [
+            err("xx", error_type="encoding_error", severity="critical"),
+            err("yy", error_type="encoding_error", severity="critical"),
+        ]
+        q = score_page(CLEAN_TEXT, errors, OcrDiagnostics())
+        assert q.encoding_error_count == 2
+
+
+class TestPhase2Captured:
+    def test_unknown_word_ratio_captured_but_weighted_zero(self):
+        # Sanity guard on the TODO marker for the corpus-populated future.
+        assert W_PHASE2_UNKNOWN == 0.0
+
+        unknown = err("བཀྲ", error_type="unknown_word", severity="warning")
+        with_unknown = score_page(CLEAN_TEXT, [unknown], OcrDiagnostics())
+        without = score_page(CLEAN_TEXT, [], OcrDiagnostics())
+
+        assert with_unknown.unknown_word_ratio > 0.0
+        # Composite must be unaffected while the weight is 0.
+        assert with_unknown.composite_score == without.composite_score
+        # Unknown words are excluded from the Phase-1 structural ratio.
+        assert with_unknown.structural_error_ratio == 0.0
+
+
+class TestDecide:
+    THRESHOLDS = Thresholds(accept=0.85, reject=0.5)
+
+    def _q(self, composite: float, encoding_errors: int = 0) -> PageQuality:
+        return PageQuality(
+            non_tibetan_char_ratio=0.0,
+            structural_error_ratio=0.0,
+            sanskrit_adjusted_error_ratio=0.0,
+            line_count_sanity=1.0,
+            encoding_error_count=encoding_errors,
+            unknown_word_ratio=0.0,
+            composite_score=composite,
+            breakdown={},
+        )
+
+    def test_high_score_accepts(self):
+        assert decide(self._q(0.95), self.THRESHOLDS) == "accept"
+
+    def test_mid_score_escalates(self):
+        assert decide(self._q(0.7), self.THRESHOLDS) == "escalate"
+
+    def test_low_score_rejects(self):
+        assert decide(self._q(0.3), self.THRESHOLDS) == "reject"
+
+    def test_encoding_error_blocks_accept(self):
+        # Composite would auto-accept, but encoding error forces escalate.
+        assert decide(self._q(0.95, encoding_errors=1), self.THRESHOLDS) == "escalate"
+
+    def test_encoding_error_still_rejects_when_score_floor_hit(self):
+        # Encoding error + already-below-reject composite → reject, not escalate.
+        assert decide(self._q(0.2, encoding_errors=1), self.THRESHOLDS) == "reject"
+
+    def test_boundary_at_accept_threshold(self):
+        # composite == accept threshold → accept (>= boundary)
+        assert decide(self._q(0.85), self.THRESHOLDS) == "accept"
+
+    def test_boundary_at_reject_threshold(self):
+        # composite == reject threshold → escalate (strict <)
+        assert decide(self._q(0.5), self.THRESHOLDS) == "escalate"
+
+
+class TestEmptyText:
+    def test_empty_text_has_zero_ratios(self):
+        q = score_page("", [], OcrDiagnostics())
+        assert q.non_tibetan_char_ratio == 0.0
+        assert q.structural_error_ratio == 0.0
+        assert q.sanskrit_adjusted_error_ratio == 0.0
+        # No expected line count → sanity defaults to 1.0, composite stays 1.0.
+        assert q.composite_score == 1.0

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -258,10 +258,10 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** Threshold tuning (T-09). Phase 2 corpus weight (later, when corpus is populated).
 
 **Acceptance criteria:**
-- [ ] Module + functions exist with documented composite formula
-- [ ] Uses T-02's Sanskrit scorer to compute `sanskrit_adjusted_error_ratio`
-- [ ] Phase 2 inputs are present in the function signature but weighted at 0 for now, with a TODO marker
-- [ ] Unit tests with hand-crafted inputs covering each branch of `decide`
+- [x] Module + functions exist with documented composite formula
+- [x] Uses T-02's Sanskrit scorer to compute `sanskrit_adjusted_error_ratio`
+- [x] Phase 2 inputs are present in the function signature but weighted at 0 for now, with a TODO marker
+- [x] Unit tests with hand-crafted inputs covering each branch of `decide`
 
 **Dependencies:** T-02
 


### PR DESCRIPTION
## What's in here

Adds the page quality scorer (`backend/app/ocr_assist/quality.py`) that drives
the accept/escalate/reject decision in the per-page retry loop. It's a weighted
composite of four signals: non-Tibetan char ratio, Phase-1 structural error
ratio, line count sanity, and an encoding-error hard floor. The interesting bit
is the Sanskrit-adjusted error ratio — it uses T-02's likelihood scores to strip
Sanskrit syllables from the structural penalty numerator so mantras and dharanis
don't tank an otherwise clean page.

Phase-2 (corpus lookup) is plumbed into the signature and the composite formula,
but weighted at 0.0 with a TODO comment until the word corpus is actually
populated. No signature change needed when that day comes.

## Worth a closer look

The encoding-error hard floor in `decide()` — any non-zero encoding error count
blocks `accept` regardless of composite score. That looks stricter than the
thresholds suggest, but it's intentional: a wrong-codepoint substitution can
score perfectly on structure while being silently wrong.

**Acceptance criteria:**
- [x] Module + functions exist with documented composite formula
- [x] Uses T-02's Sanskrit scorer to compute `sanskrit_adjusted_error_ratio`
- [x] Phase 2 inputs are present in the function signature but weighted at 0 for now, with a TODO marker
- [x] Unit tests with hand-crafted inputs covering each branch of `decide`