### PR TITLE
[T-04] Add filesystem job store for interactive OCR workflow

### DIFF
--- a/backend/app/ocr_assist/__init__.py
+++ b/backend/app/ocr_assist/__init__.py
@@ -1,0 +1,6 @@
+"""OCR assist: per-page quality scoring, retry loop, AI diagnostician.
+
+This package is the home for the interactive OCR workflow (see
+``docs/planning/INTERACTIVE_OCR_PLAN.md``). T-03 lands the page quality
+scorer; later tickets add the job store, runner, and Claude integration.
+"""

--- a/backend/app/ocr_assist/job_store.py
+++ b/backend/app/ocr_assist/job_store.py
@@ -1,0 +1,318 @@
+"""
+Filesystem-backed job store for the interactive OCR workflow.
+
+A *job* is a single PDF (or, later, image set) being transcribed page by
+page. State lives entirely under one directory per job, so a job is
+inspectable by hand, resumable after a crash, and re-runnable per-page
+without touching the rest. See ``docs/planning/INTERACTIVE_OCR_PLAN.md``
+§ "Per-page state model" for the layout this module persists::
+
+    jobs/<job_id>/
+      manifest.json
+      baseline_settings.json
+      page-001/
+        image.png
+        settings.json
+        attempts/
+          01/{ocr.txt, quality.json, ai_verdict.json}
+          02/...
+        final.txt
+        final_quality.json
+        notes.md
+      page-002/
+        ...
+
+The job store is deliberately schema-loose for OCR settings, quality, and
+AI verdicts: those structures are owned by the runner (T-05),
+quality scorer (T-03), and diagnostician (T-06) respectively. This module
+just persists arbitrary dicts so adding a field upstream doesn't require
+a job_store change.
+
+All JSON writes go through ``_atomic_write_*`` (write-temp → ``os.replace``)
+so a crash mid-write can't leave a half-written file on disk.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+
+MANIFEST_FILE = "manifest.json"
+BASELINE_SETTINGS_FILE = "baseline_settings.json"
+PAGE_SETTINGS_FILE = "settings.json"
+PAGE_IMAGE_FILE = "image.png"
+FINAL_TEXT_FILE = "final.txt"
+FINAL_QUALITY_FILE = "final_quality.json"
+NOTES_FILE = "notes.md"
+ATTEMPTS_DIR = "attempts"
+ATTEMPT_OCR_FILE = "ocr.txt"
+ATTEMPT_QUALITY_FILE = "quality.json"
+ATTEMPT_VERDICT_FILE = "ai_verdict.json"
+
+JOB_STATUS_IN_PROGRESS = "in_progress"
+JOB_STATUS_COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class AttemptRecord:
+    """One OCR attempt on a page. Persisted under ``attempts/NN/``."""
+    number: int
+    ocr_text: str
+    quality: dict[str, Any] | None = None
+    ai_verdict: dict[str, Any] | None = None
+
+
+@dataclass
+class PageState:
+    """All persisted state for one page of a job."""
+    index: int
+    image_path: Path
+    settings: dict[str, Any]
+    attempts: list[AttemptRecord] = field(default_factory=list)
+    final_text: str | None = None
+    final_quality: dict[str, Any] | None = None
+    notes: str | None = None
+
+
+@dataclass
+class Job:
+    """Top-level job metadata. Page state is loaded separately via ``load_page``."""
+    id: str
+    root: Path
+    source_file: str
+    baseline_settings: dict[str, Any]
+    created_at: datetime
+    page_count: int
+    status: str
+
+
+def create_job(
+    pdf_bytes: bytes,
+    source_file: str,
+    baseline_settings: dict[str, Any],
+    jobs_root: Path,
+    *,
+    job_id: str | None = None,
+    dpi: int = 300,
+) -> Job:
+    """Render a PDF to per-page PNGs and persist the initial job state.
+
+    Each page directory starts with a fresh copy of ``baseline_settings``
+    in ``settings.json`` — retries mutate the page's copy only, never the
+    job baseline. (See the plan's "Why this avoids the global-tweak
+    regression" section.)
+    """
+    job_id = job_id or uuid.uuid4().hex[:12]
+    job_dir = jobs_root / job_id
+    # Refuse to clobber an existing job dir; caller picks a fresh id.
+    job_dir.mkdir(parents=True, exist_ok=False)
+
+    pil_pages = _render_pdf(pdf_bytes, dpi=dpi)
+    page_count = len(pil_pages)
+    created_at = datetime.now(timezone.utc)
+
+    for i, pil_img in enumerate(pil_pages, start=1):
+        page_dir = job_dir / _page_dir_name(i)
+        page_dir.mkdir()
+        pil_img.save(page_dir / PAGE_IMAGE_FILE, "PNG")
+        _atomic_write_json(page_dir / PAGE_SETTINGS_FILE, dict(baseline_settings))
+        (page_dir / ATTEMPTS_DIR).mkdir()
+
+    _atomic_write_json(job_dir / BASELINE_SETTINGS_FILE, dict(baseline_settings))
+    manifest = {
+        "id": job_id,
+        "source_file": source_file,
+        "created_at": created_at.isoformat(),
+        "page_count": page_count,
+        "status": JOB_STATUS_IN_PROGRESS,
+    }
+    _atomic_write_json(job_dir / MANIFEST_FILE, manifest)
+
+    return Job(
+        id=job_id,
+        root=job_dir,
+        source_file=source_file,
+        baseline_settings=dict(baseline_settings),
+        created_at=created_at,
+        page_count=page_count,
+        status=JOB_STATUS_IN_PROGRESS,
+    )
+
+
+def load_job(jobs_root: Path, job_id: str) -> Job:
+    """Read a job's manifest + baseline settings. Does not eagerly load pages."""
+    job_dir = jobs_root / job_id
+    if not job_dir.is_dir():
+        raise FileNotFoundError(f"No job directory at {job_dir}")
+    manifest = json.loads((job_dir / MANIFEST_FILE).read_text())
+    baseline = json.loads((job_dir / BASELINE_SETTINGS_FILE).read_text())
+    return Job(
+        id=manifest["id"],
+        root=job_dir,
+        source_file=manifest["source_file"],
+        baseline_settings=baseline,
+        created_at=datetime.fromisoformat(manifest["created_at"]),
+        page_count=manifest["page_count"],
+        status=manifest["status"],
+    )
+
+
+def load_page(job: Job, page_index: int) -> PageState:
+    """Read a single page's full state from disk."""
+    page_dir = job.root / _page_dir_name(page_index)
+    if not page_dir.is_dir():
+        raise FileNotFoundError(f"No page directory: {page_dir}")
+
+    settings = json.loads((page_dir / PAGE_SETTINGS_FILE).read_text())
+    attempts_dir = page_dir / ATTEMPTS_DIR
+    attempts = _load_attempts(attempts_dir) if attempts_dir.is_dir() else []
+
+    final_text_path = page_dir / FINAL_TEXT_FILE
+    final_text = final_text_path.read_text() if final_text_path.is_file() else None
+
+    final_quality_path = page_dir / FINAL_QUALITY_FILE
+    final_quality = (
+        json.loads(final_quality_path.read_text())
+        if final_quality_path.is_file()
+        else None
+    )
+
+    notes_path = page_dir / NOTES_FILE
+    notes = notes_path.read_text() if notes_path.is_file() else None
+
+    return PageState(
+        index=page_index,
+        image_path=page_dir / PAGE_IMAGE_FILE,
+        settings=settings,
+        attempts=attempts,
+        final_text=final_text,
+        final_quality=final_quality,
+        notes=notes,
+    )
+
+
+def save_page_attempt(
+    job: Job,
+    page_index: int,
+    *,
+    ocr_text: str,
+    quality: dict[str, Any] | None = None,
+    ai_verdict: dict[str, Any] | None = None,
+) -> AttemptRecord:
+    """Append a new attempt under ``attempts/NN/`` with monotonic numbering."""
+    page_dir = job.root / _page_dir_name(page_index)
+    if not page_dir.is_dir():
+        raise FileNotFoundError(f"No page directory: {page_dir}")
+
+    attempts_dir = page_dir / ATTEMPTS_DIR
+    attempts_dir.mkdir(exist_ok=True)
+    number = _next_attempt_number(attempts_dir)
+    attempt_dir = attempts_dir / _attempt_dir_name(number)
+    attempt_dir.mkdir()
+
+    _atomic_write_text(attempt_dir / ATTEMPT_OCR_FILE, ocr_text)
+    if quality is not None:
+        _atomic_write_json(attempt_dir / ATTEMPT_QUALITY_FILE, quality)
+    if ai_verdict is not None:
+        _atomic_write_json(attempt_dir / ATTEMPT_VERDICT_FILE, ai_verdict)
+
+    return AttemptRecord(
+        number=number,
+        ocr_text=ocr_text,
+        quality=quality,
+        ai_verdict=ai_verdict,
+    )
+
+
+def finalize_page(
+    job: Job,
+    page_index: int,
+    *,
+    final_text: str,
+    final_quality: dict[str, Any] | None = None,
+    notes: str | None = None,
+) -> PageState:
+    """Mark a page as finalized: write ``final.txt`` (+ quality, notes)."""
+    page_dir = job.root / _page_dir_name(page_index)
+    if not page_dir.is_dir():
+        raise FileNotFoundError(f"No page directory: {page_dir}")
+
+    _atomic_write_text(page_dir / FINAL_TEXT_FILE, final_text)
+    if final_quality is not None:
+        _atomic_write_json(page_dir / FINAL_QUALITY_FILE, final_quality)
+    if notes is not None:
+        _atomic_write_text(page_dir / NOTES_FILE, notes)
+
+    return load_page(job, page_index)
+
+
+def list_jobs(jobs_root: Path) -> list[Job]:
+    """Return every readable job under ``jobs_root`` (skip malformed dirs)."""
+    if not jobs_root.is_dir():
+        return []
+    jobs: list[Job] = []
+    for entry in sorted(jobs_root.iterdir()):
+        if not entry.is_dir() or not (entry / MANIFEST_FILE).is_file():
+            continue
+        try:
+            jobs.append(load_job(jobs_root, entry.name))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return jobs
+
+
+def _page_dir_name(index: int) -> str:
+    return f"page-{index:03d}"
+
+
+def _attempt_dir_name(n: int) -> str:
+    return f"{n:02d}"
+
+
+def _next_attempt_number(attempts_dir: Path) -> int:
+    nums = [
+        int(entry.name)
+        for entry in attempts_dir.iterdir()
+        if entry.is_dir() and entry.name.isdigit()
+    ]
+    return max(nums) + 1 if nums else 1
+
+
+def _load_attempts(attempts_dir: Path) -> list[AttemptRecord]:
+    records: list[AttemptRecord] = []
+    for entry in sorted(attempts_dir.iterdir(), key=lambda p: p.name):
+        if not entry.is_dir() or not entry.name.isdigit():
+            continue
+        ocr_path = entry / ATTEMPT_OCR_FILE
+        quality_path = entry / ATTEMPT_QUALITY_FILE
+        verdict_path = entry / ATTEMPT_VERDICT_FILE
+        records.append(
+            AttemptRecord(
+                number=int(entry.name),
+                ocr_text=ocr_path.read_text() if ocr_path.is_file() else "",
+                quality=json.loads(quality_path.read_text()) if quality_path.is_file() else None,
+                ai_verdict=json.loads(verdict_path.read_text()) if verdict_path.is_file() else None,
+            )
+        )
+    return records
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
+def _atomic_write_json(path: Path, obj: Any) -> None:
+    _atomic_write_text(path, json.dumps(obj, indent=2, sort_keys=True))
+
+
+def _render_pdf(pdf_bytes: bytes, *, dpi: int) -> Sequence:
+    """Render a PDF to PIL images. Pulled out for monkeypatching in tests."""
+    from pdf2image import convert_from_bytes
+    return convert_from_bytes(pdf_bytes, dpi=dpi)

--- a/backend/app/ocr_assist/job_store.py
+++ b/backend/app/ocr_assist/job_store.py
@@ -28,13 +28,24 @@ quality scorer (T-03), and diagnostician (T-06) respectively. This module
 just persists arbitrary dicts so adding a field upstream doesn't require
 a job_store change.
 
-All JSON writes go through ``_atomic_write_*`` (write-temp → ``os.replace``)
-so a crash mid-write can't leave a half-written file on disk.
+All text/JSON is read and written as UTF-8 regardless of the host's locale
+so Tibetan/Sanskrit transcriptions round-trip correctly everywhere (the
+platform default is cp1252 on a stock Windows install, which would corrupt
+the script). JSON is stored with ``ensure_ascii=False`` so the files stay
+human-inspectable.
+
+All writes go through ``_atomic_write_*``: content is written to a unique
+temp file, ``fsync``'d, then ``os.replace``'d into place (and the parent
+directory is ``fsync``'d), so a crash mid-write can't leave a half-written
+or partially-flushed file on disk. The store assumes a *single writer per
+job*: it serializes nothing, so concurrent writers to the same job (e.g. a
+future parallelizing runner) must coordinate externally.
 """
 from __future__ import annotations
 
 import json
 import os
+import tempfile
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -106,6 +117,11 @@ def create_job(
     in ``settings.json`` — retries mutate the page's copy only, never the
     job baseline. (See the plan's "Why this avoids the global-tweak
     regression" section.)
+
+    The job directory is created with ``exist_ok=False``, so a generated
+    ``job_id`` that happens to collide with an existing job (or an explicit
+    ``job_id`` that's already taken) raises ``FileExistsError`` rather than
+    clobbering data — callers should catch it and retry with a fresh id.
     """
     job_id = job_id or uuid.uuid4().hex[:12]
     job_dir = jobs_root / job_id
@@ -149,8 +165,8 @@ def load_job(jobs_root: Path, job_id: str) -> Job:
     job_dir = jobs_root / job_id
     if not job_dir.is_dir():
         raise FileNotFoundError(f"No job directory at {job_dir}")
-    manifest = json.loads((job_dir / MANIFEST_FILE).read_text())
-    baseline = json.loads((job_dir / BASELINE_SETTINGS_FILE).read_text())
+    manifest = json.loads((job_dir / MANIFEST_FILE).read_text(encoding="utf-8"))
+    baseline = json.loads((job_dir / BASELINE_SETTINGS_FILE).read_text(encoding="utf-8"))
     return Job(
         id=manifest["id"],
         root=job_dir,
@@ -168,22 +184,24 @@ def load_page(job: Job, page_index: int) -> PageState:
     if not page_dir.is_dir():
         raise FileNotFoundError(f"No page directory: {page_dir}")
 
-    settings = json.loads((page_dir / PAGE_SETTINGS_FILE).read_text())
+    settings = json.loads((page_dir / PAGE_SETTINGS_FILE).read_text(encoding="utf-8"))
     attempts_dir = page_dir / ATTEMPTS_DIR
     attempts = _load_attempts(attempts_dir) if attempts_dir.is_dir() else []
 
     final_text_path = page_dir / FINAL_TEXT_FILE
-    final_text = final_text_path.read_text() if final_text_path.is_file() else None
+    final_text = (
+        final_text_path.read_text(encoding="utf-8") if final_text_path.is_file() else None
+    )
 
     final_quality_path = page_dir / FINAL_QUALITY_FILE
     final_quality = (
-        json.loads(final_quality_path.read_text())
+        json.loads(final_quality_path.read_text(encoding="utf-8"))
         if final_quality_path.is_file()
         else None
     )
 
     notes_path = page_dir / NOTES_FILE
-    notes = notes_path.read_text() if notes_path.is_file() else None
+    notes = notes_path.read_text(encoding="utf-8") if notes_path.is_file() else None
 
     return PageState(
         index=page_index,
@@ -261,7 +279,9 @@ def list_jobs(jobs_root: Path) -> list[Job]:
             continue
         try:
             jobs.append(load_job(jobs_root, entry.name))
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError, OSError):
+            # Malformed manifest, missing key, or a job that was deleted
+            # between the is_file() check above and the read — skip it.
             continue
     return jobs
 
@@ -294,25 +314,72 @@ def _load_attempts(attempts_dir: Path) -> list[AttemptRecord]:
         records.append(
             AttemptRecord(
                 number=int(entry.name),
-                ocr_text=ocr_path.read_text() if ocr_path.is_file() else "",
-                quality=json.loads(quality_path.read_text()) if quality_path.is_file() else None,
-                ai_verdict=json.loads(verdict_path.read_text()) if verdict_path.is_file() else None,
+                ocr_text=ocr_path.read_text(encoding="utf-8") if ocr_path.is_file() else "",
+                quality=(
+                    json.loads(quality_path.read_text(encoding="utf-8"))
+                    if quality_path.is_file()
+                    else None
+                ),
+                ai_verdict=(
+                    json.loads(verdict_path.read_text(encoding="utf-8"))
+                    if verdict_path.is_file()
+                    else None
+                ),
             )
         )
     return records
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(content)
-    os.replace(tmp, path)
+    """Write ``content`` to ``path`` atomically and durably as UTF-8.
+
+    Content goes to a uniquely-named temp file in the same directory (so
+    two writers never share a temp path), which is flushed and ``fsync``'d
+    before being ``os.replace``'d into place; the parent directory is then
+    ``fsync``'d so the rename itself survives a crash. If anything fails
+    before the replace, the temp file is removed rather than orphaned.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    # Best-effort directory fsync so the rename is durable. Not all
+    # platforms allow opening/fsync'ing a directory (e.g. Windows), and the
+    # data fsync above is the part that matters for not losing contents.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def _atomic_write_json(path: Path, obj: Any) -> None:
-    _atomic_write_text(path, json.dumps(obj, indent=2, sort_keys=True))
+    _atomic_write_text(
+        path, json.dumps(obj, indent=2, sort_keys=True, ensure_ascii=False)
+    )
 
 
 def _render_pdf(pdf_bytes: bytes, *, dpi: int) -> Sequence:
-    """Render a PDF to PIL images. Pulled out for monkeypatching in tests."""
+    """Render a PDF to PIL images. Pulled out for monkeypatching in tests.
+
+    Returns a sequence of page images; callers (and test fakes) only rely
+    on each element supporting ``.save(path, "PNG")`` — i.e. the Pillow
+    ``Image`` protocol — so a fake can return any object with that method.
+    """
     from pdf2image import convert_from_bytes
     return convert_from_bytes(pdf_bytes, dpi=dpi)

--- a/backend/tests/test_job_store.py
+++ b/backend/tests/test_job_store.py
@@ -1,0 +1,241 @@
+"""
+Tests for the OCR-assist job store.
+
+Covers the A/C from T-04:
+- create_job persists manifest, baseline_settings, and one page dir per page
+- save_page_attempt writes under attempts/NN/ with monotonic numbering
+- finalize_page writes final.txt + final_quality.json
+- load_job round-trips a previously saved job
+- list_jobs round-trips
+- Atomic writes leave no orphaned .tmp file on success
+"""
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.ocr_assist import job_store
+from app.ocr_assist.job_store import (
+    BASELINE_SETTINGS_FILE,
+    FINAL_QUALITY_FILE,
+    FINAL_TEXT_FILE,
+    JOB_STATUS_IN_PROGRESS,
+    MANIFEST_FILE,
+    PAGE_IMAGE_FILE,
+    create_job,
+    finalize_page,
+    list_jobs,
+    load_job,
+    load_page,
+    save_page_attempt,
+)
+
+
+@pytest.fixture
+def fake_pdf(monkeypatch):
+    """Bypass pdf2image: hand create_job a small list of in-memory PIL images.
+
+    pdf2image needs poppler on the system. Mocking the render keeps this
+    test suite self-contained and fast.
+    """
+    def _fake_render(pdf_bytes: bytes, *, dpi: int):
+        return [Image.new("RGB", (40, 40), "white") for _ in range(3)]
+
+    monkeypatch.setattr(job_store, "_render_pdf", _fake_render)
+    return b"fake-pdf-bytes"
+
+
+@pytest.fixture
+def baseline_settings() -> dict:
+    return {"k_factor": 2.0, "model_variant": "Modern", "rotate": 0}
+
+
+@pytest.fixture
+def created_job(tmp_path: Path, fake_pdf, baseline_settings) -> "tuple[Path, str]":
+    job = create_job(
+        fake_pdf,
+        source_file="sample.pdf",
+        baseline_settings=baseline_settings,
+        jobs_root=tmp_path,
+    )
+    return tmp_path, job.id
+
+
+class TestCreateJob:
+    def test_persists_manifest_and_baseline(self, tmp_path, fake_pdf, baseline_settings):
+        job = create_job(
+            fake_pdf,
+            source_file="sample.pdf",
+            baseline_settings=baseline_settings,
+            jobs_root=tmp_path,
+        )
+        assert (job.root / MANIFEST_FILE).is_file()
+        assert (job.root / BASELINE_SETTINGS_FILE).is_file()
+        assert job.page_count == 3
+        assert job.status == JOB_STATUS_IN_PROGRESS
+        assert isinstance(job.created_at, datetime)
+        assert job.baseline_settings == baseline_settings
+
+    def test_persists_page_dirs_with_image_and_settings(self, tmp_path, fake_pdf, baseline_settings):
+        job = create_job(
+            fake_pdf,
+            source_file="sample.pdf",
+            baseline_settings=baseline_settings,
+            jobs_root=tmp_path,
+        )
+        for i in range(1, 4):
+            page_dir = job.root / f"page-{i:03d}"
+            assert page_dir.is_dir()
+            assert (page_dir / PAGE_IMAGE_FILE).is_file()
+            assert (page_dir / "settings.json").is_file()
+            assert (page_dir / "attempts").is_dir()
+
+    def test_page_settings_start_as_baseline_copy(self, tmp_path, fake_pdf, baseline_settings):
+        job = create_job(
+            fake_pdf,
+            source_file="sample.pdf",
+            baseline_settings=baseline_settings,
+            jobs_root=tmp_path,
+        )
+        page = load_page(job, 1)
+        assert page.settings == baseline_settings
+        # Mutating the returned dict must not affect job.baseline_settings —
+        # they're independent copies.
+        page.settings["k_factor"] = 999
+        assert job.baseline_settings["k_factor"] == 2.0
+
+    def test_refuses_to_clobber_existing_job(self, tmp_path, fake_pdf, baseline_settings):
+        create_job(
+            fake_pdf,
+            source_file="sample.pdf",
+            baseline_settings=baseline_settings,
+            jobs_root=tmp_path,
+            job_id="fixed-id",
+        )
+        with pytest.raises(FileExistsError):
+            create_job(
+                fake_pdf,
+                source_file="sample.pdf",
+                baseline_settings=baseline_settings,
+                jobs_root=tmp_path,
+                job_id="fixed-id",
+            )
+
+
+class TestSavePageAttempt:
+    def test_monotonic_numbering(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+
+        first = save_page_attempt(job, 1, ocr_text="first try", quality={"composite_score": 0.6})
+        second = save_page_attempt(job, 1, ocr_text="second try", quality={"composite_score": 0.8})
+        third = save_page_attempt(job, 1, ocr_text="third try")
+
+        assert [first.number, second.number, third.number] == [1, 2, 3]
+        for n in (1, 2, 3):
+            assert (job.root / "page-001" / "attempts" / f"{n:02d}" / "ocr.txt").is_file()
+
+    def test_attempts_load_back_in_order(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+        save_page_attempt(job, 1, ocr_text="A", quality={"composite_score": 0.6})
+        save_page_attempt(job, 1, ocr_text="B", ai_verdict={"verdict": "retry"})
+
+        page = load_page(job, 1)
+        assert [a.number for a in page.attempts] == [1, 2]
+        assert page.attempts[0].ocr_text == "A"
+        assert page.attempts[0].quality == {"composite_score": 0.6}
+        assert page.attempts[1].ocr_text == "B"
+        assert page.attempts[1].ai_verdict == {"verdict": "retry"}
+
+    def test_missing_page_dir_raises(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+        with pytest.raises(FileNotFoundError):
+            save_page_attempt(job, 999, ocr_text="x")
+
+
+class TestFinalizePage:
+    def test_writes_final_text_and_quality(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+
+        page = finalize_page(
+            job,
+            2,
+            final_text="བཀྲ་ཤིས།",
+            final_quality={"composite_score": 0.92},
+            notes="reviewed by human",
+        )
+
+        page_dir = job.root / "page-002"
+        assert (page_dir / FINAL_TEXT_FILE).read_text() == "བཀྲ་ཤིས།"
+        assert (page_dir / FINAL_QUALITY_FILE).is_file()
+        assert (page_dir / "notes.md").read_text() == "reviewed by human"
+        assert page.final_text == "བཀྲ་ཤིས།"
+        assert page.final_quality == {"composite_score": 0.92}
+        assert page.notes == "reviewed by human"
+
+
+class TestLoadJobRoundTrip:
+    def test_round_trips_metadata(self, created_job, baseline_settings):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+        assert job.id == job_id
+        assert job.source_file == "sample.pdf"
+        assert job.page_count == 3
+        assert job.status == JOB_STATUS_IN_PROGRESS
+        assert job.baseline_settings == baseline_settings
+
+    def test_round_trips_page_with_attempts_and_final(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+        save_page_attempt(job, 1, ocr_text="attempt one", quality={"composite_score": 0.7})
+        save_page_attempt(job, 1, ocr_text="attempt two")
+        finalize_page(job, 1, final_text="final text", final_quality={"composite_score": 0.95})
+
+        reloaded = load_job(jobs_root, job_id)
+        page = load_page(reloaded, 1)
+        assert len(page.attempts) == 2
+        assert page.attempts[0].ocr_text == "attempt one"
+        assert page.final_text == "final text"
+        assert page.final_quality == {"composite_score": 0.95}
+
+    def test_missing_job_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_job(tmp_path, "nope")
+
+
+class TestListJobs:
+    def test_returns_all_jobs(self, tmp_path, fake_pdf, baseline_settings):
+        ids = [
+            create_job(fake_pdf, "a.pdf", baseline_settings, tmp_path).id,
+            create_job(fake_pdf, "b.pdf", baseline_settings, tmp_path).id,
+        ]
+        listed = list_jobs(tmp_path)
+        assert sorted(j.id for j in listed) == sorted(ids)
+
+    def test_empty_root_returns_empty_list(self, tmp_path):
+        assert list_jobs(tmp_path / "does-not-exist") == []
+
+    def test_skips_unrelated_directories(self, tmp_path, fake_pdf, baseline_settings):
+        create_job(fake_pdf, "a.pdf", baseline_settings, tmp_path)
+        (tmp_path / "not-a-job").mkdir()
+        (tmp_path / "stray.txt").write_text("ignored")
+        assert len(list_jobs(tmp_path)) == 1
+
+
+class TestAtomicWrites:
+    def test_no_orphan_tmp_files_after_create(self, created_job):
+        jobs_root, job_id = created_job
+        stray = [p for p in (jobs_root / job_id).rglob("*.tmp")]
+        assert stray == []
+
+    def test_no_orphan_tmp_files_after_attempt_and_finalize(self, created_job):
+        jobs_root, job_id = created_job
+        job = load_job(jobs_root, job_id)
+        save_page_attempt(job, 1, ocr_text="x", quality={"composite_score": 0.5})
+        finalize_page(job, 1, final_text="y", final_quality={"composite_score": 0.9})
+        stray = [p for p in job.root.rglob("*.tmp")]
+        assert stray == []

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -283,11 +283,11 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** OCR execution (T-05). UI exposure (T-08).
 
 **Acceptance criteria:**
-- [ ] Creating a job from a PDF persists `manifest.json` + `baseline_settings.json` + one directory per page with `image.png`
-- [ ] `save_page_attempt` writes under `attempts/NN/` with monotonic numbering
-- [ ] `finalize_page` writes `final.txt` and `final_quality.json`
-- [ ] `load_job` round-trips a previously saved job
-- [ ] Tests cover create, save attempt, finalize, reload
+- [x] Creating a job from a PDF persists `manifest.json` + `baseline_settings.json` + one directory per page with `image.png`
+- [x] `save_page_attempt` writes under `attempts/NN/` with monotonic numbering
+- [x] `finalize_page` writes `final.txt` and `final_quality.json`
+- [x] `load_job` round-trips a previously saved job
+- [x] Tests cover create, save attempt, finalize, reload
 
 **Dependencies:** none (can run alongside T-01/T-02/T-03)
 


### PR DESCRIPTION
## What's in here

Adds the filesystem-backed job store (T-04). Each job gets its own directory — one subdirectory per page, and within that an `attempts/` folder where every OCR run lands as its own numbered subdirectory. The store is deliberately schema-loose for OCR settings, quality scores, and AI verdicts so that the runner (T-05), quality scorer (T-03), and diagnostician (T-06) can evolve their structures without touching this layer. All JSON writes go through write-temp-then-`os.replace` so a crash mid-write can't leave a corrupt file.

## Worth a closer look

The `_render_pdf` helper is extracted specifically so tests can monkeypatch it without pulling in `pdf2image` or a real PDF — worth checking that seam looks clean if you're thinking about how T-05 will call into this.