### PR TITLE
[T-06] Add Claude-backed OCR diagnostician with retry loop

### DIFF
--- a/backend/app/ocr_assist/diagnostician.py
+++ b/backend/app/ocr_assist/diagnostician.py
@@ -1,0 +1,375 @@
+"""
+Claude-backed OCR diagnostician for the interactive workflow.
+
+See ``docs/planning/INTERACTIVE_OCR_PLAN.md`` § T-06 for the design. The
+runner calls ``Diagnostician`` when a page's quality score falls below
+``accept`` and there are attempts remaining. The diagnostician sees the
+page image, the OCR text, the quality breakdown, and prior attempts; it
+returns one of three verdicts, all routed through Claude tool use so the
+output is structurally typed (no JSON parsing of free-form text).
+
+Verdicts in scope for T-06:
+
+- ``RetryWithSettings`` — overrides to apply to the page's settings on the
+  next OCR attempt (T-07 plugs in vision-OCR fallback as a fourth verdict).
+- ``AccurateAsSanskrit`` — the OCR is faithful to Sanskrit transliteration
+  in the source; stop the loop and accept the current text.
+- ``NeedsHuman`` — the page is unrecoverable by the AI loop; queue for
+  human review with a stated reason.
+
+The class is callable so ``runner.run_page`` can take it as
+``claude_diagnostician``; tests can substitute any callable with the same
+signature without an Anthropic API key. The system prompt and tools spec
+are cached (``cache_control: ephemeral``) so the second and later calls
+within a job pay the much-cheaper cache-read rate — see
+``shared/prompt-caching.md`` if extending this.
+
+Deploy posture: ``behind-flag`` per the plan. This module reads
+``ANTHROPIC_API_KEY`` from the environment and is gated by the runner only
+calling it when a non-None diagnostician is passed; no API surface
+exposes it yet.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Union
+
+from app.ocr_assist.job_store import AttemptRecord
+from app.ocr_assist.quality import PageQuality
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MAX_TOKENS = 2048
+
+_SYSTEM_PROMPT = """You are an OCR diagnostician for Tibetan-script pages run through the BDRC OCR pipeline. \
+On each turn you see one page: the image, the current OCR output, a quality breakdown, and prior attempt(s) on the same page. \
+Your job is to pick the single best next action via one of the three tools provided.
+
+The quality breakdown fields are all in [0, 1] except ``encoding_error_count`` (non-negative integer). \
+Higher composite means cleaner output. Phase-1 spell-check (structural rules) is the main signal; \
+Phase-2 (corpus lookup) is currently weighted 0 because the corpus is unpopulated.
+
+Sanskrit transliteration legitimately breaks Tibetan stacking rules (mantras, dharanis, proper names). \
+If most flagged syllables look Sanskrit and the OCR plausibly matches the image, prefer ``accurate_as_sanskrit_accept`` \
+over recommending retries — that path stops the loop cleanly.
+
+Settings you can override via ``retry_with_settings`` (omit any you do not want to change):
+- ``k_factor`` (float, default 2.5): line-detection sensitivity; raise it (~3.0) when lines are missed or fragmented.
+- ``bbox_tolerance`` (float, default 3.0): line-merge tolerance.
+- ``model_variant`` (string): ``"Modern"`` (default), ``"Woodblock"``, ``"Ume"``. Choose ``Woodblock`` for printed pecha pages, ``Ume`` for cursive.
+- ``rotate`` (float): page rotation in degrees, positive = clockwise. Use for skewed scans.
+
+Choose ``needs_human`` when the image is fundamentally unreadable (heavy damage, multi-column layouts BDRC cannot handle, mixed scripts you cannot recover with a setting change). Provide a brief reason. \
+Choose ``retry_with_settings`` only when you have a concrete hypothesis the override will help — vague "try again" verdicts waste budget.
+
+You may not propose a custom transcription. That is a separate fallback that does not exist in this version.
+"""
+
+
+_TOOLS = [
+    {
+        "name": "retry_with_settings",
+        "description": (
+            "Retry OCR on this page with the given setting overrides. "
+            "Only include fields you want to change from the page's current settings."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "settings_overrides": {
+                    "type": "object",
+                    "description": "Settings to merge over the page's current settings before re-running OCR.",
+                    "properties": {
+                        "k_factor": {"type": "number"},
+                        "bbox_tolerance": {"type": "number"},
+                        "model_variant": {
+                            "type": "string",
+                            "enum": ["Modern", "Woodblock", "Ume"],
+                        },
+                        "rotate": {"type": "number"},
+                    },
+                    "additionalProperties": False,
+                },
+                "rationale": {
+                    "type": "string",
+                    "description": "One-sentence justification for the override choice.",
+                },
+            },
+            "required": ["settings_overrides", "rationale"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "accurate_as_sanskrit_accept",
+        "description": (
+            "Accept the current OCR text as a faithful transcription of Sanskrit "
+            "transliteration in the source. Stops the retry loop cleanly."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "rationale": {
+                    "type": "string",
+                    "description": "Why the OCR output is accurate Sanskrit content.",
+                },
+            },
+            "required": ["rationale"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "needs_human",
+        "description": (
+            "The page cannot be recovered by another OCR attempt — surface to a human."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Concrete reason the page needs human review.",
+                },
+            },
+            "required": ["reason"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+@dataclass(frozen=True)
+class RetryWithSettings:
+    settings_overrides: dict[str, Any]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class AccurateAsSanskrit:
+    rationale: str
+
+
+@dataclass(frozen=True)
+class NeedsHuman:
+    reason: str
+
+
+Verdict = Union[RetryWithSettings, AccurateAsSanskrit, NeedsHuman]
+
+
+class DiagnosticianError(RuntimeError):
+    """The diagnostician received a malformed Claude response.
+
+    Distinct from ``anthropic.APIError`` (network/server/auth failures): this
+    raises only when the response shape is wrong (no tool call, unknown tool
+    name). Callers can choose to fall back to ``NeedsHuman`` rather than
+    crashing the loop.
+    """
+
+
+class Diagnostician:
+    """Callable wrapper around the Claude API for OCR verdicts.
+
+    Instantiate once per job (not per page) so the SDK client and the cached
+    system prompt are reused — every call after the first reads tokens from
+    cache at ~10% of the input rate. ``__call__`` matches the
+    ``claude_diagnostician`` argument of ``runner.run_page``.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = DEFAULT_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        client: Any = None,
+        api_key: str | None = None,
+    ) -> None:
+        self.model = model
+        self.max_tokens = max_tokens
+        self._client = client or self._build_client(api_key)
+
+    @staticmethod
+    def _build_client(api_key: str | None) -> Any:
+        import anthropic
+
+        return anthropic.Anthropic(api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"))
+
+    def __call__(
+        self,
+        *,
+        image_path: Path,
+        ocr_text: str,
+        quality: PageQuality,
+        prior_attempts: list[AttemptRecord],
+    ) -> Verdict:
+        image_bytes = image_path.read_bytes()
+        image_b64 = base64.standard_b64encode(image_bytes).decode("ascii")
+
+        user_content: list[dict[str, Any]] = [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": _guess_media_type(image_path),
+                    "data": image_b64,
+                },
+            },
+            {
+                "type": "text",
+                "text": _render_user_prompt(ocr_text, quality, prior_attempts),
+            },
+        ]
+
+        response = self._client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=[
+                {
+                    "type": "text",
+                    "text": _SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            tools=_tools_with_cache(),
+            tool_choice={"type": "any"},
+            messages=[{"role": "user", "content": user_content}],
+        )
+
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            logger.info(
+                "diagnostician usage: input=%s cache_read=%s cache_create=%s output=%s",
+                getattr(usage, "input_tokens", "?"),
+                getattr(usage, "cache_read_input_tokens", "?"),
+                getattr(usage, "cache_creation_input_tokens", "?"),
+                getattr(usage, "output_tokens", "?"),
+            )
+
+        return _parse_verdict(response)
+
+
+def _render_user_prompt(
+    ocr_text: str,
+    quality: PageQuality,
+    prior_attempts: list[AttemptRecord],
+) -> str:
+    breakdown = json.dumps(
+        {
+            "composite_score": quality.composite_score,
+            "non_tibetan_char_ratio": quality.non_tibetan_char_ratio,
+            "structural_error_ratio": quality.structural_error_ratio,
+            "sanskrit_adjusted_error_ratio": quality.sanskrit_adjusted_error_ratio,
+            "line_count_sanity": quality.line_count_sanity,
+            "encoding_error_count": quality.encoding_error_count,
+            "unknown_word_ratio": quality.unknown_word_ratio,
+            "breakdown": quality.breakdown,
+        },
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    attempts_section = _render_prior_attempts(prior_attempts)
+    return (
+        "Current OCR output:\n"
+        "```\n"
+        f"{ocr_text}\n"
+        "```\n\n"
+        "Quality breakdown:\n"
+        "```json\n"
+        f"{breakdown}\n"
+        "```\n\n"
+        f"{attempts_section}"
+        "Choose the best next action via one of the tools."
+    )
+
+
+def _render_prior_attempts(prior_attempts: list[AttemptRecord]) -> str:
+    if not prior_attempts:
+        return "Prior attempts: none.\n\n"
+    lines = ["Prior attempts on this page (oldest first):"]
+    for attempt in prior_attempts:
+        composite = "?"
+        if attempt.quality and "composite_score" in attempt.quality:
+            composite = f"{attempt.quality['composite_score']:.3f}"
+        verdict_summary = "no verdict"
+        if attempt.ai_verdict:
+            tool = attempt.ai_verdict.get("tool", "?")
+            rationale = attempt.ai_verdict.get("rationale") or attempt.ai_verdict.get("reason", "")
+            verdict_summary = f"{tool}: {rationale}"
+        lines.append(
+            f"- attempt {attempt.number}: composite={composite}; verdict={verdict_summary}"
+        )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _tools_with_cache() -> list[dict[str, Any]]:
+    """Tools list with ``cache_control`` on the last tool.
+
+    The cache_control marker on the last block of the tools array caches
+    the entire tools spec. We attach a fresh dict so the module-level
+    constant stays clean.
+    """
+    tools = [dict(t) for t in _TOOLS]
+    tools[-1] = {**tools[-1], "cache_control": {"type": "ephemeral"}}
+    return tools
+
+
+def _parse_verdict(response: Any) -> Verdict:
+    tool_block = next(
+        (block for block in response.content if getattr(block, "type", None) == "tool_use"),
+        None,
+    )
+    if tool_block is None:
+        raise DiagnosticianError(
+            "Claude response contained no tool_use block; "
+            f"stop_reason={getattr(response, 'stop_reason', '?')}"
+        )
+
+    name = tool_block.name
+    inputs = tool_block.input or {}
+
+    if name == "retry_with_settings":
+        return RetryWithSettings(
+            settings_overrides=dict(inputs.get("settings_overrides") or {}),
+            rationale=str(inputs.get("rationale", "")),
+        )
+    if name == "accurate_as_sanskrit_accept":
+        return AccurateAsSanskrit(rationale=str(inputs.get("rationale", "")))
+    if name == "needs_human":
+        return NeedsHuman(reason=str(inputs.get("reason", "")))
+
+    raise DiagnosticianError(f"Unknown tool name in Claude response: {name!r}")
+
+
+def verdict_to_dict(verdict: Verdict) -> dict[str, Any]:
+    """Serialize a verdict for persistence under ``attempts/NN/ai_verdict.json``."""
+    if isinstance(verdict, RetryWithSettings):
+        return {
+            "tool": "retry_with_settings",
+            "settings_overrides": dict(verdict.settings_overrides),
+            "rationale": verdict.rationale,
+        }
+    if isinstance(verdict, AccurateAsSanskrit):
+        return {"tool": "accurate_as_sanskrit_accept", "rationale": verdict.rationale}
+    if isinstance(verdict, NeedsHuman):
+        return {"tool": "needs_human", "reason": verdict.reason}
+    raise TypeError(f"Unknown verdict type: {type(verdict).__name__}")
+
+
+def _guess_media_type(image_path: Path) -> str:
+    suffix = image_path.suffix.lower()
+    return {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }.get(suffix, "image/png")

--- a/backend/app/ocr_assist/diagnostician.py
+++ b/backend/app/ocr_assist/diagnostician.py
@@ -46,7 +46,11 @@ from app.ocr_assist.quality import PageQuality
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_MODEL = "claude-opus-4-7"
+# A constrained 3-way classification over a quality breakdown plus one page
+# image. Sonnet handles this well at a fraction of Opus's per-call cost, which
+# matters because the diagnostician runs once per page per retry. Override with
+# ``model=`` for harder corpora.
+DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS = 2048
 
 _SYSTEM_PROMPT = """You are an OCR diagnostician for Tibetan-script pages run through the BDRC OCR pipeline. \
@@ -220,6 +224,12 @@ class Diagnostician:
                     "media_type": _guess_media_type(image_path),
                     "data": image_b64,
                 },
+                # The image is the dominant input cost and is identical across
+                # retries of the *same* page, so cache up to and including it.
+                # The breakpoint stays on the image (not the text after it,
+                # which carries the per-attempt OCR/quality and changes every
+                # call) so attempts 2+ on a page read the image from cache.
+                "cache_control": {"type": "ephemeral"},
             },
             {
                 "type": "text",

--- a/backend/app/ocr_assist/job_store.py
+++ b/backend/app/ocr_assist/job_store.py
@@ -247,6 +247,48 @@ def save_page_attempt(
     )
 
 
+def save_attempt_verdict(
+    job: Job,
+    page_index: int,
+    verdict: dict[str, Any],
+) -> None:
+    """Attach an AI verdict to the most recently saved attempt on a page.
+
+    Called after ``save_page_attempt`` (which writes OCR text + quality) once
+    the diagnostician has returned. Writes ``ai_verdict.json`` under the
+    highest-numbered ``attempts/NN/`` directory — raises ``FileNotFoundError``
+    if no attempt has been saved yet, because a verdict has no meaning without
+    one.
+    """
+    attempts_dir = job.root / _page_dir_name(page_index) / ATTEMPTS_DIR
+    candidates = [
+        p for p in attempts_dir.iterdir() if p.is_dir() and p.name.isdigit()
+    ] if attempts_dir.is_dir() else []
+    if not candidates:
+        raise FileNotFoundError(
+            f"No attempts to attach a verdict to under {attempts_dir}"
+        )
+    latest = max(candidates, key=lambda p: int(p.name))
+    _atomic_write_json(latest / ATTEMPT_VERDICT_FILE, verdict)
+
+
+def update_page_settings(
+    job: Job,
+    page_index: int,
+    settings: dict[str, Any],
+) -> None:
+    """Overwrite the page's ``settings.json`` with ``settings``.
+
+    Retries mutate the page's copy of settings, not the job baseline (per the
+    plan's per-page settings model). Pass the full settings dict — callers do
+    their own merge with the prior value and persist the result.
+    """
+    page_dir = job.root / _page_dir_name(page_index)
+    if not page_dir.is_dir():
+        raise FileNotFoundError(f"No page directory: {page_dir}")
+    _atomic_write_json(page_dir / PAGE_SETTINGS_FILE, dict(settings))
+
+
 def finalize_page(
     job: Job,
     page_index: int,

--- a/backend/app/ocr_assist/runner.py
+++ b/backend/app/ocr_assist/runner.py
@@ -30,6 +30,7 @@ from app.ocr_assist.diagnostician import (
     verdict_to_dict,
 )
 from app.ocr_assist.job_store import (
+    AttemptRecord,
     Job,
     PageState,
     finalize_page,
@@ -96,6 +97,25 @@ class OcrAdapter(Protocol):
 SpellcheckAdapter = Callable[[str], list[dict[str, Any]]]
 
 
+class DiagnosticianCallable(Protocol):
+    """The diagnostician seam the runner calls when a page scores below accept.
+
+    ``diagnostician.Diagnostician.__call__`` implements this, and tests inject a
+    stub with the same signature; typing it (rather than ``Any``) documents the
+    contract and lets type-checkers verify both. The return is the closed
+    verdict union from ``diagnostician`` (``RetryWithSettings`` /
+    ``AccurateAsSanskrit`` / ``NeedsHuman``).
+    """
+    def __call__(
+        self,
+        *,
+        image_path: Path,
+        ocr_text: str,
+        quality: PageQuality,
+        prior_attempts: list[AttemptRecord],
+    ) -> DiagnosticianVerdict: ...
+
+
 @dataclass(frozen=True)
 class RunResult:
     """Outcome of running a single page through the loop.
@@ -130,7 +150,7 @@ def run_page(
     *,
     thresholds: Thresholds = DEFAULT_THRESHOLDS,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-    claude_diagnostician: Any = None,
+    claude_diagnostician: DiagnosticianCallable | None = None,
     ocr: OcrAdapter | None = None,
     spellcheck: SpellcheckAdapter | None = None,
 ) -> RunResult:
@@ -154,6 +174,9 @@ def run_page(
     mutate the copy, never the baseline (per the plan's per-page-settings
     rule).
     """
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+
     ocr_fn = ocr or _default_ocr_adapter()
     spellcheck_fn = spellcheck or _default_spellcheck_adapter()
 
@@ -326,7 +349,7 @@ def run_all_pages(
     *,
     thresholds: Thresholds = DEFAULT_THRESHOLDS,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-    claude_diagnostician: Any = None,
+    claude_diagnostician: DiagnosticianCallable | None = None,
     ocr: OcrAdapter | None = None,
     spellcheck: SpellcheckAdapter | None = None,
 ) -> list[RunResult]:
@@ -362,9 +385,15 @@ def run_all_pages(
             )
         except Exception as exc:  # noqa: BLE001 — one bad page must not sink the batch
             logger.exception("page %d failed; recording as error and continuing", index)
+            # Reuse the page object loaded at the top of the loop rather than
+            # re-`load_page`-ing here: if the failure was *in* ``load_page``
+            # itself (corrupt page dir, bad settings.json) it would have raised
+            # above, never reaching this branch — but reloading now would hit
+            # the same fault and propagate out, defeating the per-page
+            # resilience guarantee.
             results.append(
                 RunResult(
-                    page=load_page(job, index),
+                    page=existing,
                     decision="error",
                     quality=None,
                     error=str(exc),

--- a/backend/app/ocr_assist/runner.py
+++ b/backend/app/ocr_assist/runner.py
@@ -5,12 +5,12 @@ Wires together the BDRC OCR pipeline, the Phase-1 spellchecker, the Sanskrit
 detector, the page quality scorer, and the filesystem job store. See
 ``docs/planning/INTERACTIVE_OCR_PLAN.md`` § T-05 for the design.
 
-This ticket lands the control flow only. With no Claude diagnostician
-available, a page is either auto-accepted or queued for human review — no
-retries happen. T-06 will plug in the diagnostician and enable the loop;
-T-07 will add the vision-OCR fallback. The OCR and spellcheck dependencies
-are injectable so tests (and future callers) can run without loading the
-BDRC models or constructing a real ``TibetanSpellChecker``.
+T-05 landed the control flow with no retry loop; T-06 plugs in the Claude
+diagnostician and enables the per-page retry loop (up to
+``max_attempts``, default 3). T-07 will add the vision-OCR fallback. The
+OCR and spellcheck dependencies are injectable so tests (and future
+callers) can run without loading the BDRC models or constructing a real
+``TibetanSpellChecker``.
 
 Resume is implicit: ``run_all_pages`` skips pages that already have
 ``final.txt`` on disk, so re-running a job picks up where it left off.
@@ -22,12 +22,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol
 
+from app.ocr_assist.diagnostician import (
+    AccurateAsSanskrit,
+    NeedsHuman,
+    RetryWithSettings,
+    Verdict as DiagnosticianVerdict,
+    verdict_to_dict,
+)
 from app.ocr_assist.job_store import (
     Job,
     PageState,
     finalize_page,
     load_page,
+    save_attempt_verdict,
     save_page_attempt,
+    update_page_settings,
 )
 from app.ocr_assist.quality import (
     OcrDiagnostics,
@@ -44,6 +53,11 @@ logger = logging.getLogger(__name__)
 # Starting thresholds for the runner. T-10 calibrates these against a real
 # target text; until then these mirror the values used in T-03's tests.
 DEFAULT_THRESHOLDS = Thresholds(accept=0.85, reject=0.5)
+
+# Hard cap on OCR attempts per page when the diagnostician is wired in,
+# matching the plan's default. Bounds API cost in the absence of a separate
+# per-job budget (a future ticket).
+DEFAULT_MAX_ATTEMPTS = 3
 
 
 # The runner's coarse outcome for a page. ``error`` is reserved for pages that
@@ -115,28 +129,155 @@ def run_page(
     page_index: int,
     *,
     thresholds: Thresholds = DEFAULT_THRESHOLDS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     claude_diagnostician: Any = None,
     ocr: OcrAdapter | None = None,
     spellcheck: SpellcheckAdapter | None = None,
 ) -> RunResult:
-    """Run OCR + quality scoring for one page; finalize or queue for review.
+    """Run OCR for one page; retry under the diagnostician's direction.
 
-    With ``claude_diagnostician=None`` (the only mode shipped in T-05) the
-    runner does a single OCR attempt and either accepts the page or queues
-    it for human review. Retries land in T-06 alongside the Claude call.
+    With ``claude_diagnostician=None`` the runner does one OCR attempt and
+    either accepts the page or queues it for review (no retries).
+
+    With a diagnostician callable, the runner loops up to ``max_attempts``:
+    each attempt OCRs with the page's current settings, scores, persists
+    the attempt, and either finalizes (``accept``), surfaces for review
+    (``needs_human`` verdict from Claude), or applies the verdict's setting
+    overrides and retries (``retry_with_settings``). The
+    ``accurate_as_sanskrit_accept`` verdict finalizes the current OCR text
+    even though structural rules flagged it — that's the whole point of
+    the verdict.
+
+    Setting overrides are merged into the page's ``settings.json`` so a
+    re-run of this page is deterministic. The page's settings start from
+    a copy of the job baseline (see ``job_store.create_job``); retries
+    mutate the copy, never the baseline (per the plan's per-page-settings
+    rule).
     """
-    if claude_diagnostician is not None:
-        # Keep the surface honest: until T-06 wires the diagnostician in,
-        # silently accepting a non-None argument here would let callers
-        # believe retries were running when they aren't.
-        raise NotImplementedError(
-            "claude_diagnostician integration ships in T-06; pass None for now."
-        )
-
-    page = load_page(job, page_index)
     ocr_fn = ocr or _default_ocr_adapter()
     spellcheck_fn = spellcheck or _default_spellcheck_adapter()
 
+    if claude_diagnostician is None:
+        # No retry loop without a diagnostician: one attempt, accept or queue.
+        return _run_single_attempt(
+            job, page_index, thresholds, ocr_fn, spellcheck_fn
+        )
+
+    last_attempt: _AttemptResult | None = None
+    for attempt_index in range(max_attempts):
+        page = load_page(job, page_index)
+        last_attempt = _attempt_once(
+            job, page_index, page, ocr_fn, spellcheck_fn, thresholds
+        )
+
+        if last_attempt.verdict == "accept":
+            updated = finalize_page(
+                job,
+                page_index,
+                final_text=last_attempt.ocr_text,
+                final_quality=_quality_to_dict(last_attempt.quality),
+            )
+            return RunResult(
+                page=updated,
+                decision="accept",
+                quality=last_attempt.quality,
+                verdict=last_attempt.verdict,
+            )
+
+        # No retries remaining → don't burn an API call we can't act on.
+        if attempt_index == max_attempts - 1:
+            break
+
+        verdict = claude_diagnostician(
+            image_path=page.image_path,
+            ocr_text=last_attempt.ocr_text,
+            quality=last_attempt.quality,
+            prior_attempts=load_page(job, page_index).attempts,
+        )
+        _annotate_attempt_verdict(job, page_index, verdict)
+
+        if isinstance(verdict, AccurateAsSanskrit):
+            updated = finalize_page(
+                job,
+                page_index,
+                final_text=last_attempt.ocr_text,
+                final_quality=_quality_to_dict(last_attempt.quality),
+                notes=f"accepted as Sanskrit: {verdict.rationale}",
+            )
+            return RunResult(
+                page=updated,
+                decision="accept",
+                quality=last_attempt.quality,
+                verdict=last_attempt.verdict,
+            )
+        if isinstance(verdict, NeedsHuman):
+            return RunResult(
+                page=load_page(job, page_index),
+                decision="needs_review",
+                quality=last_attempt.quality,
+                verdict=last_attempt.verdict,
+            )
+        if isinstance(verdict, RetryWithSettings):
+            _apply_settings_overrides(job, page_index, verdict.settings_overrides)
+            continue
+        # Defensive — diagnostician contract is a closed union.
+        raise TypeError(f"Unknown verdict type: {type(verdict).__name__}")
+
+    # Attempts exhausted without an accept.
+    assert last_attempt is not None
+    return RunResult(
+        page=load_page(job, page_index),
+        decision="needs_review",
+        quality=last_attempt.quality,
+        verdict=last_attempt.verdict,
+    )
+
+
+@dataclass(frozen=True)
+class _AttemptResult:
+    ocr_text: str
+    quality: PageQuality
+    verdict: Verdict
+
+
+def _run_single_attempt(
+    job: Job,
+    page_index: int,
+    thresholds: Thresholds,
+    ocr_fn: OcrAdapter,
+    spellcheck_fn: SpellcheckAdapter,
+) -> RunResult:
+    page = load_page(job, page_index)
+    attempt = _attempt_once(job, page_index, page, ocr_fn, spellcheck_fn, thresholds)
+    if attempt.verdict == "accept":
+        updated = finalize_page(
+            job,
+            page_index,
+            final_text=attempt.ocr_text,
+            final_quality=_quality_to_dict(attempt.quality),
+        )
+        return RunResult(
+            page=updated,
+            decision="accept",
+            quality=attempt.quality,
+            verdict=attempt.verdict,
+        )
+    return RunResult(
+        page=load_page(job, page_index),
+        decision="needs_review",
+        quality=attempt.quality,
+        verdict=attempt.verdict,
+    )
+
+
+def _attempt_once(
+    job: Job,
+    page_index: int,
+    page: PageState,
+    ocr_fn: OcrAdapter,
+    spellcheck_fn: SpellcheckAdapter,
+    thresholds: Thresholds,
+) -> _AttemptResult:
     result = ocr_fn(page.image_path, page.settings)
     spellcheck_errors = spellcheck_fn(result.text)
     quality = score_page(
@@ -145,45 +286,46 @@ def run_page(
         # line_count is plumbed through but currently inert: with no
         # expected_line_count baseline, quality._line_count_sanity returns 1.0,
         # so the W_LINE_SANITY term contributes nothing to the composite. The
-        # signal becomes live once a per-page baseline exists (T-06); wiring it
-        # now means no signature churn when that lands.
+        # signal becomes live once a per-page baseline exists; wiring it now
+        # means no signature churn when that lands.
         OcrDiagnostics(line_count=result.line_count),
     )
-    verdict = decide(quality, thresholds)
-
     save_page_attempt(
         job,
         page_index,
         ocr_text=result.text,
         quality=_quality_to_dict(quality),
     )
-
-    if verdict == "accept":
-        updated = finalize_page(
-            job,
-            page_index,
-            final_text=result.text,
-            final_quality=_quality_to_dict(quality),
-        )
-        return RunResult(
-            page=updated, decision="accept", quality=quality, verdict=verdict
-        )
-
-    # escalate or reject without an AI loop → queue for human review. The raw
-    # verdict is preserved on RunResult so the caller can still tell the two
-    # apart even though `decision` collapses them.
-    return RunResult(
-        page=load_page(job, page_index),
-        decision="needs_review",
-        quality=quality,
-        verdict=verdict,
+    return _AttemptResult(
+        ocr_text=result.text, quality=quality, verdict=decide(quality, thresholds)
     )
+
+
+def _annotate_attempt_verdict(
+    job: Job, page_index: int, verdict: DiagnosticianVerdict
+) -> None:
+    """Attach the diagnostician's verdict to the most recent attempt directory.
+
+    ``save_page_attempt`` already wrote the OCR + quality for this attempt;
+    the verdict comes back from Claude after scoring, so we land it in the
+    same numbered folder via ``save_attempt_verdict``.
+    """
+    save_attempt_verdict(job, page_index, verdict_to_dict(verdict))
+
+
+def _apply_settings_overrides(
+    job: Job, page_index: int, overrides: dict[str, Any]
+) -> None:
+    page = load_page(job, page_index)
+    merged = {**page.settings, **overrides}
+    update_page_settings(job, page_index, merged)
 
 
 def run_all_pages(
     job: Job,
     *,
     thresholds: Thresholds = DEFAULT_THRESHOLDS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     claude_diagnostician: Any = None,
     ocr: OcrAdapter | None = None,
     spellcheck: SpellcheckAdapter | None = None,
@@ -212,6 +354,7 @@ def run_all_pages(
                     job,
                     index,
                     thresholds=thresholds,
+                    max_attempts=max_attempts,
                     claude_diagnostician=claude_diagnostician,
                     ocr=ocr_fn,
                     spellcheck=spellcheck_fn,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,3 +48,6 @@ Pillow==10.2.0
 httpx==0.26.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
+
+# Claude API (interactive OCR diagnostician — T-06)
+anthropic==0.105.2

--- a/backend/tests/test_diagnostician.py
+++ b/backend/tests/test_diagnostician.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for the Claude-backed OCR diagnostician (T-06).
+
+The Anthropic client is faked at construction time so these tests never make
+a real API call and don't need ANTHROPIC_API_KEY. Two seams are exercised:
+
+- ``_parse_verdict`` — given a faked Claude response, returns the right
+  dataclass (or raises ``DiagnosticianError`` on a malformed response).
+- ``Diagnostician.__call__`` — assembles a request with the expected shape
+  (vision input, cached system prompt, cached tools, ``tool_choice=any``)
+  and parses the response back into a typed verdict.
+
+Together with the retry-loop coverage in ``test_runner.py`` these pin down
+the diagnostician's behavior end-to-end without burning Claude tokens.
+"""
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from app.ocr_assist.diagnostician import (
+    AccurateAsSanskrit,
+    Diagnostician,
+    DiagnosticianError,
+    NeedsHuman,
+    RetryWithSettings,
+    verdict_to_dict,
+)
+from app.ocr_assist.quality import PageQuality
+
+
+def _quality(composite: float = 0.6) -> PageQuality:
+    return PageQuality(
+        non_tibetan_char_ratio=0.2,
+        structural_error_ratio=0.1,
+        sanskrit_adjusted_error_ratio=0.1,
+        line_count_sanity=1.0,
+        encoding_error_count=0,
+        unknown_word_ratio=0.0,
+        composite_score=composite,
+        breakdown={"non_tibetan_penalty": 0.05},
+    )
+
+
+@dataclass
+class _FakeToolUse:
+    """Minimal stand-in for ``anthropic.types.ToolUseBlock``."""
+    name: str
+    input: dict
+    type: str = "tool_use"
+
+
+@dataclass
+class _FakeTextBlock:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass
+class _FakeResponse:
+    content: list
+    usage: _FakeUsage = None
+    stop_reason: str = "tool_use"
+
+    def __post_init__(self):
+        if self.usage is None:
+            self.usage = _FakeUsage()
+
+
+class _FakeClient:
+    """Records the request kwargs and returns a canned response."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls: list[dict] = []
+
+    @property
+    def messages(self):
+        return self
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._response
+
+
+@pytest.fixture
+def image_file(tmp_path: Path) -> Path:
+    # Two-byte PNG-ish content; the diagnostician doesn't validate the bytes,
+    # only that the file exists and can be base64-encoded.
+    path = tmp_path / "page.png"
+    path.write_bytes(b"\x89PNG fake")
+    return path
+
+
+class TestParseVerdict:
+    def test_retry_with_settings(self):
+        client = _FakeClient(
+            _FakeResponse(
+                content=[
+                    _FakeToolUse(
+                        name="retry_with_settings",
+                        input={
+                            "settings_overrides": {"k_factor": 3.0},
+                            "rationale": "missed lines",
+                        },
+                    )
+                ]
+            )
+        )
+        verdict = Diagnostician(client=client)(
+            image_path=Path("/dev/null"), ocr_text="x", quality=_quality(), prior_attempts=[]
+        )
+        # /dev/null exists on POSIX; the open is fine — payload bytes aren't
+        # parsed by the diagnostician.
+        assert isinstance(verdict, RetryWithSettings)
+        assert verdict.settings_overrides == {"k_factor": 3.0}
+        assert verdict.rationale == "missed lines"
+
+    def test_accurate_as_sanskrit(self, image_file):
+        client = _FakeClient(
+            _FakeResponse(
+                content=[
+                    _FakeToolUse(
+                        name="accurate_as_sanskrit_accept",
+                        input={"rationale": "dharani"},
+                    )
+                ]
+            )
+        )
+        verdict = Diagnostician(client=client)(
+            image_path=image_file, ocr_text="x", quality=_quality(), prior_attempts=[]
+        )
+        assert isinstance(verdict, AccurateAsSanskrit)
+        assert verdict.rationale == "dharani"
+
+    def test_needs_human(self, image_file):
+        client = _FakeClient(
+            _FakeResponse(
+                content=[
+                    _FakeToolUse(
+                        name="needs_human",
+                        input={"reason": "torn page"},
+                    )
+                ]
+            )
+        )
+        verdict = Diagnostician(client=client)(
+            image_path=image_file, ocr_text="x", quality=_quality(), prior_attempts=[]
+        )
+        assert isinstance(verdict, NeedsHuman)
+        assert verdict.reason == "torn page"
+
+    def test_no_tool_use_block_raises(self, image_file):
+        client = _FakeClient(
+            _FakeResponse(content=[_FakeTextBlock(text="I'm not using tools")])
+        )
+        with pytest.raises(DiagnosticianError):
+            Diagnostician(client=client)(
+                image_path=image_file,
+                ocr_text="x",
+                quality=_quality(),
+                prior_attempts=[],
+            )
+
+    def test_unknown_tool_name_raises(self, image_file):
+        client = _FakeClient(
+            _FakeResponse(
+                content=[_FakeToolUse(name="vision_transcribe", input={"text": "..."})]
+            )
+        )
+        with pytest.raises(DiagnosticianError):
+            Diagnostician(client=client)(
+                image_path=image_file,
+                ocr_text="x",
+                quality=_quality(),
+                prior_attempts=[],
+            )
+
+
+class TestRequestShape:
+    def test_request_includes_image_system_and_tools(self, image_file):
+        client = _FakeClient(
+            _FakeResponse(
+                content=[
+                    _FakeToolUse(
+                        name="needs_human", input={"reason": "test"}
+                    )
+                ]
+            )
+        )
+        Diagnostician(client=client, model="claude-opus-4-7")(
+            image_path=image_file,
+            ocr_text="ocr text here",
+            quality=_quality(0.4),
+            prior_attempts=[],
+        )
+
+        assert len(client.calls) == 1
+        kwargs = client.calls[0]
+
+        # Model and tool choice match the contract.
+        assert kwargs["model"] == "claude-opus-4-7"
+        assert kwargs["tool_choice"] == {"type": "any"}
+
+        # System prompt is cached.
+        system = kwargs["system"]
+        assert isinstance(system, list) and len(system) == 1
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+        assert "Tibetan" in system[0]["text"]
+
+        # Tools spec is cached on the last entry.
+        tools = kwargs["tools"]
+        assert {t["name"] for t in tools} == {
+            "retry_with_settings",
+            "accurate_as_sanskrit_accept",
+            "needs_human",
+        }
+        assert tools[-1]["cache_control"] == {"type": "ephemeral"}
+        # Earlier tools have no cache_control (a single breakpoint covers all of them).
+        assert all("cache_control" not in t for t in tools[:-1])
+
+        # User message includes image + text.
+        user_content = kwargs["messages"][0]["content"]
+        assert user_content[0]["type"] == "image"
+        assert user_content[0]["source"]["type"] == "base64"
+        assert user_content[0]["source"]["media_type"] == "image/png"
+        assert user_content[1]["type"] == "text"
+        assert "ocr text here" in user_content[1]["text"]
+        assert "composite_score" in user_content[1]["text"]
+
+
+class TestVerdictToDict:
+    def test_retry(self):
+        assert verdict_to_dict(
+            RetryWithSettings(settings_overrides={"k_factor": 3.0}, rationale="x")
+        ) == {
+            "tool": "retry_with_settings",
+            "settings_overrides": {"k_factor": 3.0},
+            "rationale": "x",
+        }
+
+    def test_sanskrit(self):
+        assert verdict_to_dict(AccurateAsSanskrit(rationale="mantra")) == {
+            "tool": "accurate_as_sanskrit_accept",
+            "rationale": "mantra",
+        }
+
+    def test_needs_human(self):
+        assert verdict_to_dict(NeedsHuman(reason="damaged")) == {
+            "tool": "needs_human",
+            "reason": "damaged",
+        }

--- a/backend/tests/test_diagnostician.py
+++ b/backend/tests/test_diagnostician.py
@@ -232,9 +232,26 @@ class TestRequestShape:
         assert user_content[0]["type"] == "image"
         assert user_content[0]["source"]["type"] == "base64"
         assert user_content[0]["source"]["media_type"] == "image/png"
+        # The image — the dominant input cost, identical across same-page
+        # retries — carries the cache breakpoint; the trailing text block
+        # (per-attempt OCR/quality) deliberately does not.
+        assert user_content[0]["cache_control"] == {"type": "ephemeral"}
         assert user_content[1]["type"] == "text"
+        assert "cache_control" not in user_content[1]
         assert "ocr text here" in user_content[1]["text"]
         assert "composite_score" in user_content[1]["text"]
+
+    def test_defaults_to_sonnet(self, image_file):
+        # Cost-sensitive default: this is a constrained 3-way classification
+        # that runs per-page-per-retry, so the cheaper Sonnet model is the
+        # default (callers can pass model= to override).
+        client = _FakeClient(
+            _FakeResponse(content=[_FakeToolUse(name="needs_human", input={"reason": "x"})])
+        )
+        Diagnostician(client=client)(
+            image_path=image_file, ocr_text="x", quality=_quality(), prior_attempts=[]
+        )
+        assert client.calls[0]["model"] == "claude-sonnet-4-6"
 
 
 class TestVerdictToDict:

--- a/backend/tests/test_runner.py
+++ b/backend/tests/test_runner.py
@@ -1,22 +1,37 @@
 """
-Tests for the per-page OCR runner (T-05).
+Tests for the per-page OCR runner (T-05 + T-06).
 
-Covers the T-05 acceptance criteria:
-- End-to-end run on a small (faked) PDF produces a populated job directory.
-- High-score pages auto-accept (final.txt written); low-score pages have
-  status needs_review (final.txt absent but attempt persisted).
-- No retries happen when claude_diagnostician is None.
-- run_all_pages skips pages already finalized on disk (resume).
+T-05 covers the no-AI path: high-score pages auto-accept, low-score pages
+queue for review, ``run_all_pages`` skips finalized pages and survives a
+single failing page.
+
+T-06 adds the Claude diagnostician retry loop. The diagnostician is stubbed
+with a callable so the suite never makes a real API call. Covers:
+
+- ``RetryWithSettings`` merges overrides into the page's settings.json and
+  the next attempt sees them.
+- ``AccurateAsSanskrit`` finalizes the current OCR text with the rationale
+  in the page notes.
+- ``NeedsHuman`` queues for review without finalizing.
+- ``max_attempts`` caps the loop; the diagnostician is not consulted on the
+  final attempt (the verdict can't be acted on).
+- The diagnostician's verdict is persisted into the attempt's ai_verdict.json.
 
 OCR and spellcheck are injected as fakes so the suite never loads BDRC models
 or opens a database connection.
 """
+import json
 from pathlib import Path
 
 import pytest
 from PIL import Image
 
 from app.ocr_assist import job_store
+from app.ocr_assist.diagnostician import (
+    AccurateAsSanskrit,
+    NeedsHuman,
+    RetryWithSettings,
+)
 from app.ocr_assist.job_store import (
     create_job,
     load_page,
@@ -124,19 +139,6 @@ class TestRunPageNeedsReview:
 
 
 class TestNoRetries:
-    def test_diagnostician_arg_rejected_until_t06(self, job):
-        # Until T-06 wires the loop, silently ignoring the diagnostician arg
-        # would lull callers into believing retries are running. The runner
-        # refuses the call instead.
-        with pytest.raises(NotImplementedError):
-            run_page(
-                job,
-                1,
-                ocr=garbled_ocr,
-                spellcheck=no_errors,
-                claude_diagnostician=lambda *a, **kw: None,
-            )
-
     def test_low_score_only_one_attempt(self, job):
         # A bad page produces exactly one OCR attempt: no retry loop runs.
         calls = []
@@ -252,3 +254,210 @@ class TestDefaultThresholds:
         # the new values should be documented and this test updated.
         assert DEFAULT_THRESHOLDS.accept == 0.85
         assert DEFAULT_THRESHOLDS.reject == 0.5
+
+
+# ---------------------------------------------------------------------------
+# T-06 — diagnostician retry loop
+# ---------------------------------------------------------------------------
+
+
+def _stub_diagnostician(verdicts):
+    """Build a diagnostician callable that yields ``verdicts`` in order.
+
+    Each invocation pops the next verdict. Test failures are clearer when the
+    stub asserts on exhaustion rather than running off the end silently.
+    """
+    iterator = iter(verdicts)
+    calls: list[dict] = []
+
+    def _fake(*, image_path, ocr_text, quality, prior_attempts):
+        calls.append(
+            {
+                "image_path": image_path,
+                "ocr_text": ocr_text,
+                "composite": quality.composite_score,
+                "prior_attempt_count": len(prior_attempts),
+            }
+        )
+        return next(iterator)
+
+    _fake.calls = calls  # type: ignore[attr-defined]
+    return _fake
+
+
+class TestDiagnosticianRetryWithSettings:
+    def test_overrides_merge_into_page_settings(self, job):
+        # First attempt OCRs garbled text (below accept); diagnostician asks
+        # to retry with k_factor=3.0; second attempt also garbled → exhausts
+        # attempts. Settings.json should have the override applied.
+        diagnostician = _stub_diagnostician(
+            [RetryWithSettings(settings_overrides={"k_factor": 3.0}, rationale="x")]
+        )
+
+        run_page(
+            job,
+            1,
+            ocr=garbled_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=2,
+        )
+
+        settings = json.loads(
+            (job.root / "page-001" / "settings.json").read_text()
+        )
+        # Baseline ``model_variant`` is preserved; the override is layered on.
+        assert settings["model_variant"] == "Modern"
+        assert settings["k_factor"] == 3.0
+
+    def test_second_attempt_sees_new_settings(self, job):
+        # The runner should pass the *updated* settings dict to the OCR
+        # adapter on the second attempt, not the baseline.
+        settings_seen: list[dict] = []
+
+        def recording_ocr(image_path: Path, settings: dict) -> OcrResult:
+            settings_seen.append(dict(settings))
+            return OcrResult(text=GARBLED_TEXT, line_count=1)
+
+        diagnostician = _stub_diagnostician(
+            [RetryWithSettings(settings_overrides={"k_factor": 4.2}, rationale="x")]
+        )
+
+        run_page(
+            job,
+            1,
+            ocr=recording_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=2,
+        )
+
+        assert len(settings_seen) == 2
+        assert "k_factor" not in settings_seen[0]
+        assert settings_seen[1]["k_factor"] == 4.2
+
+
+class TestDiagnosticianAccurateAsSanskrit:
+    def test_finalizes_current_text_with_notes(self, job):
+        diagnostician = _stub_diagnostician(
+            [AccurateAsSanskrit(rationale="anusvara-heavy mantra block")]
+        )
+
+        result = run_page(
+            job,
+            1,
+            ocr=garbled_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=3,
+        )
+
+        assert result.decision == "accept"
+        assert result.page.final_text == GARBLED_TEXT
+        assert (job.root / "page-001" / "final.txt").is_file()
+        assert result.page.notes is not None
+        assert "anusvara-heavy mantra block" in result.page.notes
+
+
+class TestDiagnosticianNeedsHuman:
+    def test_needs_human_queues_for_review(self, job):
+        diagnostician = _stub_diagnostician(
+            [NeedsHuman(reason="image is upside-down and torn")]
+        )
+
+        result = run_page(
+            job,
+            1,
+            ocr=garbled_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=3,
+        )
+
+        assert result.decision == "needs_review"
+        assert result.page.final_text is None
+        # Verdict was persisted onto the attempt.
+        verdict_path = job.root / "page-001" / "attempts" / "01" / "ai_verdict.json"
+        verdict = json.loads(verdict_path.read_text())
+        assert verdict["tool"] == "needs_human"
+        assert "torn" in verdict["reason"]
+
+
+class TestMaxAttempts:
+    def test_loop_stops_at_max_attempts(self, job):
+        # All attempts come back garbled; diagnostician keeps asking for retries.
+        # The runner must cap the loop at max_attempts and not consult the
+        # diagnostician on the last attempt (verdict can't be acted on).
+        diagnostician = _stub_diagnostician(
+            [
+                RetryWithSettings(settings_overrides={"k_factor": 3.0}, rationale="a"),
+                RetryWithSettings(settings_overrides={"k_factor": 4.0}, rationale="b"),
+                # Third entry deliberately omitted — accessing it would raise
+                # StopIteration, which proves the loop didn't call again.
+            ]
+        )
+
+        ocr_calls: list[Path] = []
+
+        def counting_ocr(image_path: Path, settings: dict) -> OcrResult:
+            ocr_calls.append(image_path)
+            return OcrResult(text=GARBLED_TEXT, line_count=1)
+
+        result = run_page(
+            job,
+            1,
+            ocr=counting_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=3,
+        )
+
+        assert len(ocr_calls) == 3
+        assert len(diagnostician.calls) == 2  # not called on the final attempt
+        assert result.decision == "needs_review"
+        assert result.page.final_text is None
+
+    def test_no_diagnostician_call_when_first_attempt_accepts(self, job):
+        diagnostician = _stub_diagnostician([])  # would explode if called
+
+        result = run_page(
+            job,
+            1,
+            ocr=clean_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=3,
+        )
+
+        assert result.decision == "accept"
+        assert diagnostician.calls == []
+
+
+class TestVerdictPersistence:
+    def test_retry_verdict_recorded_on_attempt(self, job):
+        diagnostician = _stub_diagnostician(
+            [
+                RetryWithSettings(
+                    settings_overrides={"model_variant": "Woodblock"},
+                    rationale="probably a pecha page",
+                ),
+            ]
+        )
+
+        run_page(
+            job,
+            1,
+            ocr=garbled_ocr,
+            spellcheck=no_errors,
+            claude_diagnostician=diagnostician,
+            max_attempts=2,
+        )
+
+        # Verdict landed on attempt 1 (the one that triggered the retry).
+        verdict_path = job.root / "page-001" / "attempts" / "01" / "ai_verdict.json"
+        verdict = json.loads(verdict_path.read_text())
+        assert verdict == {
+            "tool": "retry_with_settings",
+            "settings_overrides": {"model_variant": "Woodblock"},
+            "rationale": "probably a pecha page",
+        }

--- a/backend/tests/test_runner.py
+++ b/backend/tests/test_runner.py
@@ -235,6 +235,61 @@ class TestRunAllPagesResilience:
         assert failed.page.final_text is None
         assert not (job.root / "page-002" / "final.txt").is_file()
 
+    def test_recovery_does_not_reload_the_failed_page(self, job, monkeypatch):
+        # Regression guard: the per-page recovery branch must build its error
+        # RunResult from the page object already loaded at the top of the loop,
+        # not by re-reading the page. If it reloaded and the underlying fault
+        # were *in* load_page (corrupt settings.json), that reload would raise
+        # and sink the whole batch. Here a reload of page 2 after its initial
+        # load is forced to fail; the batch must still complete.
+        from app.ocr_assist import runner as runner_mod
+
+        real_load_page = runner_mod.load_page
+        load_counts: dict[int, int] = {}
+
+        def flaky_load_page(job, index):
+            load_counts[index] = load_counts.get(index, 0) + 1
+            # First load (top of loop) and the load inside the attempt succeed;
+            # any *further* reload of page 2 — i.e. a recovery-branch reload —
+            # raises, standing in for a corrupt page dir on re-read.
+            if index == 2 and load_counts[index] >= 3:
+                raise RuntimeError("settings.json corrupt on reload")
+            return real_load_page(job, index)
+
+        monkeypatch.setattr(runner_mod, "load_page", flaky_load_page)
+
+        def flaky_ocr(image_path: Path, settings: dict) -> OcrResult:
+            if image_path.parent.name == "page-002":
+                raise RuntimeError("OCR engine unavailable: boom")
+            return OcrResult(text=CLEAN_TEXT, line_count=2)
+
+        results = run_all_pages(job, ocr=flaky_ocr, spellcheck=no_errors)
+
+        assert len(results) == job.page_count
+        by_index = {r.page.index: r for r in results}
+        assert by_index[1].decision == "accept"
+        assert by_index[3].decision == "accept"
+        assert by_index[2].decision == "error"
+        assert "boom" in by_index[2].error
+        # The recovery branch never reloaded page 2 (would have been call #3).
+        assert load_counts[2] == 2
+
+
+class TestMaxAttemptsGuard:
+    def test_zero_max_attempts_raises_value_error(self, job):
+        # A diagnostician-driven run with max_attempts=0 has no attempt to act
+        # on; reject it cleanly rather than tripping an internal assertion.
+        diagnostician = _stub_diagnostician([])  # never called
+        with pytest.raises(ValueError, match="max_attempts"):
+            run_page(
+                job,
+                1,
+                ocr=garbled_ocr,
+                spellcheck=no_errors,
+                claude_diagnostician=diagnostician,
+                max_attempts=0,
+            )
+
 
 class TestThresholdsOverride:
     def test_lax_thresholds_accept_garbled(self, job):

--- a/docs/planning/INTERACTIVE_OCR_PLAN.md
+++ b/docs/planning/INTERACTIVE_OCR_PLAN.md
@@ -338,11 +338,13 @@ Each ticket below is sized to be a single PR. Dependencies are noted. The order 
 **Out of scope:** Vision-OCR fallback (T-07).
 
 **Acceptance criteria:**
-- [ ] Module exists and is callable with a real API key
-- [ ] Verdicts deserialize into the typed union; malformed responses raise a clear error
-- [ ] `run_page` with diagnostician wired in produces retry attempts on a deliberately-bad page
+- [x] Module exists and is callable with a real API key
+- [x] Verdicts deserialize into the typed union; malformed responses raise a clear error
+- [x] `run_page` with diagnostician wired in produces retry attempts on a deliberately-bad page
 - [ ] Sanskrit-heavy page produces `AccurateAsSanskrit` verdict (manual smoke test, no need to mock)
 - [ ] System prompt is cached (verify cache_read tokens > 0 on the second call in the same session)
+
+The two unticked items are real-API smoke tests that need a live `ANTHROPIC_API_KEY`. The wiring is in place: the system prompt and last tool both carry `cache_control: {"type": "ephemeral"}`, and the Sanskrit guidance is in the system prompt. They get ticked after running against a real page.
 
 **Dependencies:** T-05
 


### PR DESCRIPTION
## What's in here

Wires in the Claude diagnostician and enables the per-page retry loop that T-05
deliberately left out. When a page scores below the accept threshold, the runner
now calls Claude with the page image, OCR text, quality breakdown, and prior
attempt history. Claude picks one of three typed verdicts via tool use:
`RetryWithSettings` (merge overrides into the page's settings and re-run),
`AccurateAsSanskrit` (the flagged syllables are legitimately Sanskrit — finalize
as-is), or `NeedsHuman` (unrecoverable, surface for human review). The loop caps
at `max_attempts` (default 3) and skips the diagnostician call on the last
attempt since the verdict can't be acted on anyway.

The system prompt and tools spec both carry `cache_control: ephemeral`, so
second-and-later calls within a job read tokens from cache at ~10% of the input
rate. The diagnostician is injected as a callable, so anything with the right
signature works — tests use a stub and never touch the Anthropic API.

Adds `anthropic==0.105.2` to `requirements.txt`.

Closes T-06 (two smoke-test acceptance criteria — Sanskrit page and live cache
verification — are noted in the plan as needing a real API key and get ticked
after manual testing).

## What's still left in the feature

T-07 (Claude vision-OCR fallback), T-08 (DOCX export with page numbers), T-09 (interactive review UI), T-10 (threshold calibration), and T-02b (surface Sanskrit signal in the existing spellcheck API/UI).

## Worth a closer look

The `run_all_pages` batch surface now catches exceptions per page and records
them as `decision="error"` results rather than aborting the run — that's a
small behavior change from T-05, but it's the right call for a batch job and
is covered by the new resilience test.