### PR TITLE
Make ThinPlateSpline import optional

### DIFF
--- a/backend/BDRC/Utils.py
+++ b/backend/BDRC/Utils.py
@@ -26,7 +26,10 @@ from math import ceil
 from uuid import uuid1
 from pathlib import Path
 from datetime import datetime
-from tps import ThinPlateSpline
+try:
+    from tps import ThinPlateSpline
+except ImportError:
+    ThinPlateSpline = None  # type: ignore[assignment,misc]
 from typing import List, Tuple, Optional, Sequence
 
 from BDRC.Data import OCRModelConfig, Platform, ScreenData, BBox, Line, \


### PR DESCRIPTION
## Summary
- `tps` isn't in `backend/requirements.txt`, so the top-level `from tps import ThinPlateSpline` in `BDRC/Utils.py` was crashing prod at import time.
- The app already passes `use_tps=False` (`backend/app/pdf/ocr.py:126`), so `ThinPlateSpline` is never actually invoked at runtime.
- Wrap the import in a try/except (mirroring the existing PySide6 optional-import shim a few lines below) so the module loads cleanly when `tps` is absent.

## Test plan
- [ ] Verify backend boots in prod without `tps` installed
- [ ] Smoke-test the existing OCR endpoint on a known-good PDF — output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)