### PR TITLE
Downscale oversized page images for Anthropic OCR assist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ postgres_data/
 uploads/
 results/
 
+# Local OCR calibration PDFs (generated via scripts/combine_to_pdf.py)
+backend/pages_for_ocr_test.pdf
+backend/combined_ocr_test.pdf
+
 # BDRC OCR model files (downloaded via scripts/download_models.py — too large for git)
 backend/OCRModels/
 backend/Models/Lines/*.onnx

--- a/backend/app/ocr_assist/providers/anthropic_common.py
+++ b/backend/app/ocr_assist/providers/anthropic_common.py
@@ -7,11 +7,16 @@ from typing import Any
 
 from app.ocr_assist.providers.media import encode_image_base64
 
+# Anthropic Messages API rejects images whose width or height exceeds 8000px.
+ANTHROPIC_MAX_IMAGE_DIMENSION = 8000
+
 
 def anthropic_image_block(
     image_path: Path, *, cache_control: dict[str, str] | None = None
 ) -> dict[str, Any]:
-    image_b64, media_type = encode_image_base64(image_path)
+    image_b64, media_type = encode_image_base64(
+        image_path, max_dimension=ANTHROPIC_MAX_IMAGE_DIMENSION
+    )
     block: dict[str, Any] = {
         "type": "image",
         "source": {

--- a/backend/app/ocr_assist/providers/media.py
+++ b/backend/app/ocr_assist/providers/media.py
@@ -2,7 +2,14 @@
 from __future__ import annotations
 
 import base64
+import io
+import logging
 from pathlib import Path
+
+from PIL import Image
+
+
+logger = logging.getLogger(__name__)
 
 
 def guess_media_type(image_path: Path) -> str:
@@ -16,9 +23,52 @@ def guess_media_type(image_path: Path) -> str:
     }.get(suffix, "image/png")
 
 
-def encode_image_base64(image_path: Path) -> tuple[str, str]:
+def load_image_bytes(
+    image_path: Path, *, max_dimension: int | None = None
+) -> tuple[bytes, str]:
+    """Return ``(image_bytes, media_type)``, downscaling when ``max_dimension`` is set."""
+    media_type = guess_media_type(image_path)
+    if max_dimension is None:
+        return image_path.read_bytes(), media_type
+
+    try:
+        with Image.open(image_path) as image:
+            width, height = image.size
+            longest = max(width, height)
+            if longest <= max_dimension:
+                return image_path.read_bytes(), media_type
+
+            scale = max_dimension / longest
+            new_size = (
+                max(int(width * scale), 1),
+                max(int(height * scale), 1),
+            )
+            logger.info(
+                "Downscaling %s from %sx%s to %sx%s for API upload (max=%spx)",
+                image_path.name,
+                width,
+                height,
+                new_size[0],
+                new_size[1],
+                max_dimension,
+            )
+            resized = image.convert("RGB").resize(new_size, Image.Resampling.LANCZOS)
+            buffer = io.BytesIO()
+            resized.save(buffer, format="PNG")
+            return buffer.getvalue(), "image/png"
+    except (OSError, Image.UnidentifiedImageError):
+        logger.warning(
+            "Could not read dimensions from %s; sending original bytes to API",
+            image_path,
+        )
+        return image_path.read_bytes(), media_type
+
+
+def encode_image_base64(
+    image_path: Path, *, max_dimension: int | None = None
+) -> tuple[str, str]:
     """Return ``(base64_data, media_type)`` for an on-disk page image."""
-    image_bytes = image_path.read_bytes()
-    return base64.standard_b64encode(image_bytes).decode("ascii"), guess_media_type(
-        image_path
+    image_bytes, media_type = load_image_bytes(
+        image_path, max_dimension=max_dimension
     )
+    return base64.standard_b64encode(image_bytes).decode("ascii"), media_type

--- a/backend/scripts/combine_to_pdf.py
+++ b/backend/scripts/combine_to_pdf.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Combine image and PDF files in a folder into a single PDF."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+from pathlib import Path
+
+from PIL import Image
+from pypdf import PdfReader, PdfWriter
+
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".bmp"}
+PDF_SUFFIXES = {".pdf"}
+
+
+def natural_key(path: Path) -> list[object]:
+    parts = re.split(r"(\d+)", path.name.lower())
+    return [int(part) if part.isdigit() else part for part in parts]
+
+
+def image_to_pdf_bytes(path: Path) -> bytes:
+    with Image.open(path) as image:
+        if image.mode in ("RGBA", "LA", "P"):
+            image = image.convert("RGB")
+        elif image.mode != "RGB":
+            image = image.convert("RGB")
+        buffer = io.BytesIO()
+        image.save(buffer, format="PDF")
+        return buffer.getvalue()
+
+
+def append_file(writer: PdfWriter, path: Path) -> None:
+    suffix = path.suffix.lower()
+    if suffix in PDF_SUFFIXES:
+        reader = PdfReader(str(path))
+        for page in reader.pages:
+            writer.add_page(page)
+        return
+    if suffix in IMAGE_SUFFIXES:
+        reader = PdfReader(io.BytesIO(image_to_pdf_bytes(path)))
+        for page in reader.pages:
+            writer.add_page(page)
+        return
+    raise ValueError(f"Unsupported file type: {path.name}")
+
+
+def combine_folder(input_dir: Path, output_path: Path) -> list[Path]:
+    files = sorted(
+        [
+            path
+            for path in input_dir.iterdir()
+            if path.is_file() and not path.name.startswith(".")
+        ],
+        key=natural_key,
+    )
+    if not files:
+        raise SystemExit(f"No files found in {input_dir}")
+
+    writer = PdfWriter()
+    for path in files:
+        append_file(writer, path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as handle:
+        writer.write(handle)
+
+    return files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_dir", type=Path, help="Folder containing pages to combine")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("pages_for_ocr_test.pdf"),
+        help="Output PDF path (default: pages_for_ocr_test.pdf)",
+    )
+    args = parser.parse_args()
+
+    if not args.input_dir.is_dir():
+        raise SystemExit(f"Input folder not found: {args.input_dir}")
+
+    files = combine_folder(args.input_dir, args.output)
+    print(f"Combined {len(files)} files into {args.output.resolve()}")
+    for path in files:
+        print(f"  - {path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -1,0 +1,68 @@
+"""Tests for OCR assist image upload helpers."""
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+
+from PIL import Image
+
+from app.ocr_assist.providers.anthropic_common import (
+    ANTHROPIC_MAX_IMAGE_DIMENSION,
+    anthropic_image_block,
+)
+from app.ocr_assist.providers.media import encode_image_base64, load_image_bytes
+
+
+def _write_png(path: Path, size: tuple[int, int]) -> None:
+    Image.new("RGB", size, color="white").save(path, format="PNG")
+
+
+class TestLoadImageBytes:
+    def test_small_image_passes_through_unchanged(self, tmp_path: Path) -> None:
+        image_path = tmp_path / "small.png"
+        _write_png(image_path, (100, 200))
+        original = image_path.read_bytes()
+
+        data, media_type = load_image_bytes(
+            image_path, max_dimension=ANTHROPIC_MAX_IMAGE_DIMENSION
+        )
+
+        assert data == original
+        assert media_type == "image/png"
+
+    def test_oversized_image_is_downscaled(self, tmp_path: Path) -> None:
+        image_path = tmp_path / "wide.png"
+        _write_png(image_path, (18267, 4134))
+
+        data, media_type = load_image_bytes(
+            image_path, max_dimension=ANTHROPIC_MAX_IMAGE_DIMENSION
+        )
+
+        assert media_type == "image/png"
+        with Image.open(io.BytesIO(data)) as resized:
+            width, height = resized.size
+        assert max(width, height) <= ANTHROPIC_MAX_IMAGE_DIMENSION
+        assert width == ANTHROPIC_MAX_IMAGE_DIMENSION
+        assert height == int(4134 * ANTHROPIC_MAX_IMAGE_DIMENSION / 18267)
+
+
+class TestEncodeImageBase64:
+    def test_anthropic_image_block_respects_dimension_limit(
+        self, tmp_path: Path
+    ) -> None:
+        image_path = tmp_path / "wide.png"
+        _write_png(image_path, (18267, 4134))
+
+        block = anthropic_image_block(image_path)
+        raw = base64.standard_b64decode(block["source"]["data"])
+        with Image.open(io.BytesIO(raw)) as resized:
+            width, height = resized.size
+
+        assert block["source"]["media_type"] == "image/png"
+        assert max(width, height) <= ANTHROPIC_MAX_IMAGE_DIMENSION
+
+        _, media_type = encode_image_base64(
+            image_path, max_dimension=ANTHROPIC_MAX_IMAGE_DIMENSION
+        )
+        assert media_type == "image/png"


### PR DESCRIPTION
## Summary
- Anthropic Messages API rejects images whose width or height exceeds 8000px
- Add `load_image_bytes(..., max_dimension=)` in `media.py` with LANCZOS downscale to PNG
- Wire `ANTHROPIC_MAX_IMAGE_DIMENSION` through `anthropic_image_block`
- Add `test_media.py` regression tests
- Add `backend/scripts/combine_to_pdf.py` for assembling local OCR smoke-test PDFs
- Gitignore generated calibration PDFs in `backend/`

## Test plan
- [x] `pytest tests/test_media.py tests/test_providers.py -q`
- [x] `yarn test:ci`

Made with [Cursor](https://cursor.com)